### PR TITLE
Add simple Jenkinsfile, no end-to-end tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,44 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent any
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  libraries {
+    lib("pay-jenkins-library@master")
+  }
+
+  environment {
+    DOCKER_HOST = "unix:///var/run/docker.sock"
+  }
+
+  stages {
+    stage('Maven Build') {
+      steps {
+        sh 'mvn clean package'
+      }
+    }
+    stage('Docker Build') {
+      steps {
+        script {
+          buildApp{
+            app = "products"
+          }
+        }
+      }
+    }
+    stage('Docker Tag') {
+      steps {
+        script {
+          dockerTag {
+            app = "products"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
At this stage, this is a bare-bones repo. In order to integrate with
the end to end tests, we need to build, unit test and push a container
to Docker Hub.

This Jenkinsfile should hopefully be just enough to get that done.

As the code evolves and we have something to integrate with the
end-to-end tests, then this Jenkinsfile can have the additional steps
added.