### PR TITLE
PP-2668 Adding DEFAULT_AWS_REGION env variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,11 +14,13 @@ pipeline {
 
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
+    AWS_DEFAULT_REGION = "eu-west-1"
   }
 
   stages {
     stage('Maven Build') {
       steps {
+        sh 'docker pull govukpay/postgres:9.4.4'
         sh 'mvn clean package'
       }
     }


### PR DESCRIPTION
It seems credstash requires an AWS_REGION to work with. Although in PaaS we haven't got such a context, adding this solely for the purpose of accessing credstash

Also adding the missing postgres container pull