### PR TITLE
Pp 2672/create payment for a product part 3

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
@@ -28,7 +28,7 @@ public class PaymentResponse {
 
     private Links links;
 
-    private String cardBrand;
+    private CardBrand cardBrand;
 
     public PaymentResponse() {
     }
@@ -47,7 +47,7 @@ public class PaymentResponse {
             @JsonProperty("settlement_summary") SettlementSummary settlementSummary,
             @JsonProperty("card_details") CardDetails cardDetails,
             @JsonProperty("_links") Links links,
-            @JsonProperty("card_brand") String cardBrand) {
+            @JsonProperty("card_brand") CardBrand cardBrand) {
         this.paymentId = paymentId;
         this.amount = amount;
         this.state = state;
@@ -168,11 +168,11 @@ public class PaymentResponse {
         this.links = links;
     }
 
-    public String getCardBrand() {
+    public CardBrand getCardBrand() {
         return cardBrand;
     }
 
-    public void setCardBrand(String cardBrand) {
+    public void setCardBrand(CardBrand cardBrand) {
         this.cardBrand = cardBrand;
     }
 

--- a/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiResponseErrorException.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
 
-class PublicApiResponseErrorException extends RuntimeException {
+public class PublicApiResponseErrorException extends RuntimeException {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PublicApiResponseErrorException.class);
 

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/CardBrand.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/CardBrand.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.products.client.publicapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum CardBrand {
+
+    @JsonProperty("Visa")
+    VISA,
+
+    @JsonProperty("Mastercard")
+    MASTER_CARD,
+
+    @JsonProperty("American Express")
+    AMERICAN_EXPRESS,
+
+    @JsonProperty("Diners Club")
+    DINERS_CLUB,
+
+    @JsonProperty("Discover")
+    DISCOVER,
+
+    @JsonProperty("Jcb")
+    JCB,
+
+    @JsonProperty("Union Pay")
+    UNIONPAY
+}

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/CardDetails.java
@@ -11,14 +11,14 @@ public class CardDetails {
     private final String cardHolderName;
     private final String expiryDate;
     private final Address billingAddress;
-    private final String cardBrand;
+    private final CardBrand cardBrand;
 
     public CardDetails(
             @JsonProperty("last_digits_card_number") String lastDigitsCardNumber,
             @JsonProperty("cardholder_name") String cardHolderName,
             @JsonProperty("expiry_date") String expiryDate,
             @JsonProperty("billing_address") Address billingAddress,
-            @JsonProperty("card_brand") String cardBrand) {
+            @JsonProperty("card_brand") CardBrand cardBrand) {
         this.lastDigitsCardNumber = lastDigitsCardNumber;
         this.cardHolderName = cardHolderName;
         this.expiryDate = expiryDate;
@@ -42,7 +42,7 @@ public class CardDetails {
         return billingAddress;
     }
 
-    public String getCardBrand() {
+    public CardBrand getCardBrand() {
         return cardBrand;
     }
 

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/Links.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/Links.java
@@ -14,6 +14,9 @@ public class Links {
     private Link refunds;
     private Link cancel;
 
+    public Links() {
+    }
+
     public Links(
             @JsonProperty("self") Link self,
             @JsonProperty("next_url") Link nextUrl,

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -81,4 +81,8 @@ public class ProductsConfiguration extends Configuration {
     public String getProductsApiToken2() {
         return productsApiToken2;
     }
+
+    public RestClientConfiguration getRestClientConfiguration() {
+        return restClientConfiguration;
+    }
 }

--- a/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
@@ -97,4 +97,16 @@ public class PaymentEntity extends AbstractEntity {
                 this.productEntity != null ? this.productEntity.getId() : null
         );
     }
+
+    @Override
+    public String toString() {
+        return "PaymentEntity{" +
+                "externalId='" + externalId + '\'' +
+                ", govukPaymentId='" + govukPaymentId + '\'' +
+                ", nextUrl='" + nextUrl + '\'' +
+                ", dateCreated=" + dateCreated +
+                ", productEntity=" + productEntity +
+                ", status=" + status +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/pay/products/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/PaymentResource.java
@@ -4,8 +4,8 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.products.model.Payment;
-import uk.gov.pay.products.service.PaymentsFactory;
-import uk.gov.pay.products.service.ProductsFactory;
+import uk.gov.pay.products.service.PaymentFactory;
+import uk.gov.pay.products.service.ProductFactory;
 
 import javax.annotation.security.PermitAll;
 import javax.ws.rs.Consumes;
@@ -32,8 +32,8 @@ public class PaymentResource {
     public static final String PAYMENTS_RESOURCE_GET_PAYMENTS = API_VERSION_PATH + "/api/products/{productId}/payments";
 
 
-    private final PaymentsFactory paymentsFactory;
-    private final ProductsFactory productsFactory;
+    private final PaymentFactory paymentsFactory;
+    private final ProductFactory productFactory;
 
     @Path(PAYMENTS_RESOURCE_GET_PAYMENT)
     @GET
@@ -51,9 +51,9 @@ public class PaymentResource {
     }
 
     @Inject
-    public PaymentResource(PaymentsFactory paymentsFactory, ProductsFactory productsFactory){
+    public PaymentResource(PaymentFactory paymentsFactory, ProductFactory productFactory){
         this.paymentsFactory = paymentsFactory;
-        this.productsFactory = productsFactory;
+        this.productFactory = productFactory;
     }
 
     @Path(PAYMENTS_RESOURCE_GET_PAYMENTS)
@@ -63,7 +63,7 @@ public class PaymentResource {
     @PermitAll
     public Response findPaymentsByProductExternalId(@PathParam("productId") String productExternalId){
         logger.info("Find a list of payments with product id - [ {} ]", productExternalId);
-        Optional<Integer> productId = productsFactory.productsFinder().findProductIdByExternalId(productExternalId);
+        Optional<Integer> productId = productFactory.productsFinder().findProductIdByExternalId(productExternalId);
         if(!productId.isPresent()){
             return Response.status(NOT_FOUND).build();
         }

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -54,7 +54,7 @@ public class ProductResource {
         return requestValidator.validateCreateRequest(payload)
                 .map(errors -> Response.status(Status.BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
-                    Product product = productFactory.productsCreator().doCreate(Product.from(payload));
+                    Product product = productFactory.productCreator().doCreate(Product.from(payload));
                     return Response.status(Status.CREATED).entity(product).build();
                 });
 
@@ -67,7 +67,7 @@ public class ProductResource {
     @PermitAll
     public Response findProduct(@PathParam("productExternalId") String productExternalId) {
         logger.info("Find a product with externalId - [ {} ]", productExternalId);
-        return productFactory.productsFinder().findByExternalId(productExternalId)
+        return productFactory.productFinder().findByExternalId(productExternalId)
                 .map(product ->
                         Response.status(OK).entity(product).build())
                 .orElseGet(() ->
@@ -81,7 +81,7 @@ public class ProductResource {
     @PermitAll
     public Response disableProduct(@PathParam("productExternalId") String productExternalId) {
         logger.info("Disabling a product with externalId - [ {} ]", productExternalId);
-        return productFactory.productsFinder().disableProduct(productExternalId)
+        return productFactory.productFinder().disableProduct(productExternalId)
                 .map(product -> Response.status(NO_CONTENT).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
@@ -92,7 +92,7 @@ public class ProductResource {
     @PermitAll
     public Response findProducts(@QueryParam("gatewayAccountId") Integer gatewayAccountId) {
         logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);
-        List<Product> products = productFactory.productsFinder().findByGatewayAccountId(gatewayAccountId);
+        List<Product> products = productFactory.productFinder().findByGatewayAccountId(gatewayAccountId);
         return products.size() > 0 ? Response.status(OK).entity(products).build() : Response.status(NOT_FOUND).build();
     }
 }

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -6,7 +6,7 @@ import io.dropwizard.jersey.PATCH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.products.model.Product;
-import uk.gov.pay.products.service.ProductsFactory;
+import uk.gov.pay.products.service.ProductFactory;
 import uk.gov.pay.products.validations.ProductRequestValidator;
 
 import javax.annotation.security.PermitAll;
@@ -35,13 +35,13 @@ public class ProductResource {
     private static final String PRODUCTS_RESOURCE_DISABLE = PRODUCTS_RESOURCE + "/{productExternalId}/disable";
 
     private final ProductRequestValidator requestValidator;
-    private final ProductsFactory productsFactory;
+    private final ProductFactory productFactory;
 
 
     @Inject
-    public ProductResource(ProductRequestValidator requestValidator, ProductsFactory productsFactory) {
+    public ProductResource(ProductRequestValidator requestValidator, ProductFactory productFactory) {
         this.requestValidator = requestValidator;
-        this.productsFactory = productsFactory;
+        this.productFactory = productFactory;
     }
 
     @POST
@@ -54,7 +54,7 @@ public class ProductResource {
         return requestValidator.validateCreateRequest(payload)
                 .map(errors -> Response.status(Status.BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
-                    Product product = productsFactory.productsCreator().doCreate(Product.from(payload));
+                    Product product = productFactory.productsCreator().doCreate(Product.from(payload));
                     return Response.status(Status.CREATED).entity(product).build();
                 });
 
@@ -67,7 +67,7 @@ public class ProductResource {
     @PermitAll
     public Response findProduct(@PathParam("productExternalId") String productExternalId) {
         logger.info("Find a product with externalId - [ {} ]", productExternalId);
-        return productsFactory.productsFinder().findByExternalId(productExternalId)
+        return productFactory.productsFinder().findByExternalId(productExternalId)
                 .map(product ->
                         Response.status(OK).entity(product).build())
                 .orElseGet(() ->
@@ -81,7 +81,7 @@ public class ProductResource {
     @PermitAll
     public Response disableProduct(@PathParam("productExternalId") String productExternalId) {
         logger.info("Disabling a product with externalId - [ {} ]", productExternalId);
-        return productsFactory.productsFinder().disableProduct(productExternalId)
+        return productFactory.productsFinder().disableProduct(productExternalId)
                 .map(product -> Response.status(NO_CONTENT).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
@@ -92,7 +92,7 @@ public class ProductResource {
     @PermitAll
     public Response findProducts(@QueryParam("gatewayAccountId") Integer gatewayAccountId) {
         logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);
-        List<Product> products = productsFactory.productsFinder().findByGatewayAccountId(gatewayAccountId);
+        List<Product> products = productFactory.productsFinder().findByGatewayAccountId(gatewayAccountId);
         return products.size() > 0 ? Response.status(OK).entity(products).build() : Response.status(NOT_FOUND).build();
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -30,7 +30,7 @@ public class PaymentCreator {
     private final ProductDao productDao;
     private final PaymentDao paymentDao;
     private final PublicApiRestClient publicApiRestClient;
-    private LinksDecorator linksDecorator;
+    private final LinksDecorator linksDecorator;
 
 
     @Inject
@@ -82,7 +82,6 @@ public class PaymentCreator {
                     productEntity.getDescription(),
                     productEntity.getReturnUrl());
 
-
             try {
                 PaymentResponse paymentResponse = publicApiRestClient.createPayment(paymentRequest);
 
@@ -98,7 +97,6 @@ public class PaymentCreator {
             return paymentEntity;
         };
     }
-
 
     private TransactionalOperation<TransactionContext, PaymentEntity> afterPaymentCreation() {
         return context -> {

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -1,0 +1,120 @@
+package uk.gov.pay.products.service;
+
+import com.google.inject.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.products.client.publicapi.PaymentRequest;
+import uk.gov.pay.products.client.publicapi.PaymentResponse;
+import uk.gov.pay.products.client.publicapi.PublicApiResponseErrorException;
+import uk.gov.pay.products.client.publicapi.PublicApiRestClient;
+import uk.gov.pay.products.model.Payment;
+import uk.gov.pay.products.persistence.dao.PaymentDao;
+import uk.gov.pay.products.persistence.dao.ProductDao;
+import uk.gov.pay.products.persistence.entity.PaymentEntity;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+import uk.gov.pay.products.service.transaction.NonTransactionalOperation;
+import uk.gov.pay.products.service.transaction.TransactionContext;
+import uk.gov.pay.products.service.transaction.TransactionFlow;
+import uk.gov.pay.products.service.transaction.TransactionalOperation;
+import uk.gov.pay.products.util.PaymentStatus;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
+
+public class PaymentCreator {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final Provider<TransactionFlow> transactionFlowProvider;
+    private final ProductDao productDao;
+    private final PaymentDao paymentDao;
+    private final PublicApiRestClient publicApiRestClient;
+    private LinksDecorator linksDecorator;
+
+
+    @Inject
+    public PaymentCreator(Provider<TransactionFlow> transactionFlowProvider, ProductDao productDao, PaymentDao paymentDao,
+                          PublicApiRestClient publicApiRestClient, LinksDecorator linksDecorator) {
+        this.transactionFlowProvider = transactionFlowProvider;
+        this.productDao = productDao;
+        this.paymentDao = paymentDao;
+        this.publicApiRestClient = publicApiRestClient;
+        this.linksDecorator = linksDecorator;
+    }
+
+    public Payment doCreate(Integer productId) {
+        PaymentEntity paymentEntity = transactionFlowProvider.get()
+                .executeNext(beforePaymentCreation(productId))
+                .executeNext(paymentCreation())
+                .executeNext(afterPaymentCreation())
+                .complete().get(PaymentEntity.class);
+
+        if (paymentEntity.getStatus() == PaymentStatus.ERROR) {
+            throw new PaymentCreatorDownstreamException(paymentEntity.getProductEntity().getId());
+        }
+        return linksDecorator.decorate(paymentEntity.toPayment());
+    }
+
+    private TransactionalOperation<TransactionContext, PaymentEntity> beforePaymentCreation(Integer productId) {
+        return context -> {
+            logger.info("Creating a new payment for productId {}", productId);
+            ProductEntity productEntity = productDao.findById(productId)
+                    .orElseThrow(() -> new PaymentCreatorNotFoundException(productId));
+
+            PaymentEntity paymentEntity = new PaymentEntity();
+            paymentEntity.setExternalId(randomUuid());
+            paymentEntity.setProductEntity(productEntity);
+            paymentEntity.setStatus(PaymentStatus.CREATED);
+            paymentDao.persist(paymentEntity);
+
+            return paymentEntity;
+        };
+    }
+
+    private NonTransactionalOperation<TransactionContext, PaymentEntity> paymentCreation() {
+        return context -> {
+            PaymentEntity paymentEntity = context.get(PaymentEntity.class);
+            ProductEntity productEntity = paymentEntity.getProductEntity();
+            PaymentRequest paymentRequest = new PaymentRequest(
+                    productEntity.getPrice(),
+                    productEntity.getExternalId(),
+                    productEntity.getDescription(),
+                    productEntity.getReturnUrl());
+
+
+            try {
+                PaymentResponse paymentResponse = publicApiRestClient.createPayment(paymentRequest);
+
+                paymentEntity.setGovukPaymentId(paymentResponse.getPaymentId());
+                paymentEntity.setNextUrl(getNextUrl(paymentResponse));
+                paymentEntity.setStatus(PaymentStatus.SUCCESS);
+                logger.info("Payment creation for productId {} successful {}", paymentEntity.getProductEntity().getId(), paymentEntity);
+            } catch (PublicApiResponseErrorException e) {
+                logger.error("Payment creation for productId {} failed {}", paymentEntity.getProductEntity().getId(), e);
+                paymentEntity.setStatus(PaymentStatus.ERROR);
+            }
+
+            return paymentEntity;
+        };
+    }
+
+
+    private TransactionalOperation<TransactionContext, PaymentEntity> afterPaymentCreation() {
+        return context -> {
+            PaymentEntity paymentEntity = context.get(PaymentEntity.class);
+            paymentDao.merge(paymentEntity);
+
+            logger.info("Payment creation for productId {} completed {}", paymentEntity.getProductEntity().getId());
+            return paymentEntity;
+        };
+    }
+
+    private String getNextUrl(PaymentResponse paymentResponse) {
+        if ((paymentResponse.getLinks() != null) &&
+                (paymentResponse.getLinks().getNextUrl() != null)) {
+            return paymentResponse.getLinks().getNextUrl().getHref();
+        }
+        return "";
+    }
+}

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreatorDownstreamException.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreatorDownstreamException.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.products.service;
+
+public class PaymentCreatorDownstreamException extends RuntimeException {
+
+    private final Integer productId;
+
+    public PaymentCreatorDownstreamException(Integer productId) {
+        this.productId = productId;
+    }
+
+    public Integer getProductId() {
+        return productId;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreatorNotFoundException.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreatorNotFoundException.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.products.service;
+
+public class PaymentCreatorNotFoundException extends RuntimeException {
+
+    private final Integer productId;
+
+    public PaymentCreatorNotFoundException(Integer productId) {
+        this.productId = productId;
+    }
+
+    public Integer getProductId() {
+        return productId;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/service/PaymentFactory.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentFactory.java
@@ -2,5 +2,5 @@ package uk.gov.pay.products.service;
 
 public interface PaymentFactory {
 
-    PaymentFinder paymentsFinder();
+    PaymentFinder paymentFinder();
 }

--- a/src/main/java/uk/gov/pay/products/service/PaymentFactory.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentFactory.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.products.service;
 
-public interface PaymentsFactory {
+public interface PaymentFactory {
 
     PaymentFinder paymentsFinder();
 }

--- a/src/main/java/uk/gov/pay/products/service/ProductCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductCreator.java
@@ -8,13 +8,13 @@ import uk.gov.pay.products.persistence.entity.ProductEntity;
 
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
-public class ProductsCreator {
+public class ProductCreator {
 
     private final ProductDao productDao;
     private final LinksDecorator linksDecorator;
 
     @Inject
-    public ProductsCreator(ProductDao productDao, LinksDecorator linksDecorator) {
+    public ProductCreator(ProductDao productDao, LinksDecorator linksDecorator) {
         this.productDao = productDao;
         this.linksDecorator = linksDecorator;
     }

--- a/src/main/java/uk/gov/pay/products/service/ProductFactory.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductFactory.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.products.service;
 
-public interface ProductsFactory {
-    ProductsCreator productsCreator();
+public interface ProductFactory {
+    ProductCreator productsCreator();
 
     ProductFinder productsFinder();
 }

--- a/src/main/java/uk/gov/pay/products/service/ProductFactory.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductFactory.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.products.service;
 
 public interface ProductFactory {
-    ProductCreator productsCreator();
+    ProductCreator productCreator();
 
-    ProductFinder productsFinder();
+    ProductFinder productFinder();
 }

--- a/src/test/java/uk/gov/pay/products/matchers/PaymentEntityMatcher.java
+++ b/src/test/java/uk/gov/pay/products/matchers/PaymentEntityMatcher.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.products.matchers;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import uk.gov.pay.products.persistence.entity.PaymentEntity;
+
+public class PaymentEntityMatcher {
+    public static Matcher<PaymentEntity> isSame(final PaymentEntity expectedPaymentEntity) {
+        return new BaseMatcher<PaymentEntity>() {
+            @Override
+            public boolean matches(final Object obj) {
+                final PaymentEntity actualPaymentEntity = (PaymentEntity) obj;
+
+                return ((actualPaymentEntity != null) &&
+                        (expectedPaymentEntity != null) &&
+                        (actualPaymentEntity.getExternalId() != null) &&
+                        (actualPaymentEntity.getNextUrl() == expectedPaymentEntity.getNextUrl()) &&
+                        (actualPaymentEntity.getStatus() == expectedPaymentEntity.getStatus()) &&
+                        (actualPaymentEntity.getGovukPaymentId() == expectedPaymentEntity.getGovukPaymentId()) &&
+                        (actualPaymentEntity.getProductEntity() == expectedPaymentEntity.getProductEntity()));
+            }
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("PaymentEntity ").appendValue(expectedPaymentEntity);
+            }
+        };
+    }
+}
+

--- a/src/test/java/uk/gov/pay/products/matchers/PaymentEntityMatcher.java
+++ b/src/test/java/uk/gov/pay/products/matchers/PaymentEntityMatcher.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.products.matchers;
 
+import org.apache.commons.lang.StringUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -15,9 +16,9 @@ public class PaymentEntityMatcher {
                 return ((actualPaymentEntity != null) &&
                         (expectedPaymentEntity != null) &&
                         (actualPaymentEntity.getExternalId() != null) &&
-                        (actualPaymentEntity.getNextUrl() == expectedPaymentEntity.getNextUrl()) &&
+                        StringUtils.equals(actualPaymentEntity.getNextUrl(), expectedPaymentEntity.getNextUrl()) &&
                         (actualPaymentEntity.getStatus() == expectedPaymentEntity.getStatus()) &&
-                        (actualPaymentEntity.getGovukPaymentId() == expectedPaymentEntity.getGovukPaymentId()) &&
+                        StringUtils.equals(actualPaymentEntity.getGovukPaymentId(), expectedPaymentEntity.getGovukPaymentId()) &&
                         (actualPaymentEntity.getProductEntity() == expectedPaymentEntity.getProductEntity()));
             }
 

--- a/src/test/java/uk/gov/pay/products/matchers/PaymentRequestMatcher.java
+++ b/src/test/java/uk/gov/pay/products/matchers/PaymentRequestMatcher.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.products.matchers;
+
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import uk.gov.pay.products.client.publicapi.PaymentRequest;
+
+public class PaymentRequestMatcher {
+    public static Matcher<PaymentRequest> isSame(final PaymentRequest expectedPaymentRequest) {
+        return new BaseMatcher<PaymentRequest>() {
+            @Override
+            public boolean matches(final Object obj) {
+                final PaymentRequest actualPaymentRequest = (PaymentRequest) obj;
+
+                return ((actualPaymentRequest != null) &&
+                        (expectedPaymentRequest != null) &&
+                        (actualPaymentRequest.getAmount() == expectedPaymentRequest.getAmount()) &&
+                        (actualPaymentRequest.getReference() == expectedPaymentRequest.getReference()) &&
+                        (actualPaymentRequest.getDescription() == expectedPaymentRequest.getDescription()) &&
+                        (actualPaymentRequest.getReturnUrl() == expectedPaymentRequest.getReturnUrl()));
+            }
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("PaymentRequest ").appendValue(expectedPaymentRequest);
+            }
+        };
+    }
+}
+

--- a/src/test/java/uk/gov/pay/products/matchers/PaymentRequestMatcher.java
+++ b/src/test/java/uk/gov/pay/products/matchers/PaymentRequestMatcher.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.products.matchers;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -16,9 +17,9 @@ public class PaymentRequestMatcher {
                 return ((actualPaymentRequest != null) &&
                         (expectedPaymentRequest != null) &&
                         (actualPaymentRequest.getAmount() == expectedPaymentRequest.getAmount()) &&
-                        (actualPaymentRequest.getReference() == expectedPaymentRequest.getReference()) &&
-                        (actualPaymentRequest.getDescription() == expectedPaymentRequest.getDescription()) &&
-                        (actualPaymentRequest.getReturnUrl() == expectedPaymentRequest.getReturnUrl()));
+                        StringUtils.equals(actualPaymentRequest.getReference(), expectedPaymentRequest.getReference()) &&
+                        StringUtils.equals(actualPaymentRequest.getDescription(), expectedPaymentRequest.getDescription()) &&
+                        StringUtils.equals(actualPaymentRequest.getReturnUrl(), expectedPaymentRequest.getReturnUrl()));
             }
 
             @Override

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -55,7 +55,7 @@ public class PaymentCreatorTest {
     public void shouldCreateASuccessfulPayment() throws Exception {
         int productId = 1;
         String productExternalId = "product-external-id";
-        long productPrice = 100l;
+        long productPrice = 100L;
         String productDescription = "description";
         String productReturnUrl = "https://return.url";
 
@@ -104,7 +104,7 @@ public class PaymentCreatorTest {
         int productId = 1;
 
         String productExternalId = "product-external-id";
-        long productPrice = 100l;
+        long productPrice = 100L;
         String productDescription = "description";
         String productReturnUrl = "https://return.url";
 
@@ -125,7 +125,6 @@ public class PaymentCreatorTest {
                 .thenThrow(PublicApiResponseErrorException.class);
 
         try {
-            Payment payment = paymentCreator.doCreate(productId);
             paymentCreator.doCreate(productId);
             fail("Expected an PaymentCreatorDownstreamException to be thrown");
         } catch (PaymentCreatorDownstreamException e) {

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -1,0 +1,191 @@
+package uk.gov.pay.products.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.products.client.publicapi.PaymentRequest;
+import uk.gov.pay.products.client.publicapi.PaymentResponse;
+import uk.gov.pay.products.client.publicapi.PublicApiResponseErrorException;
+import uk.gov.pay.products.client.publicapi.PublicApiRestClient;
+import uk.gov.pay.products.client.publicapi.model.Link;
+import uk.gov.pay.products.client.publicapi.model.Links;
+import uk.gov.pay.products.matchers.PaymentEntityMatcher;
+import uk.gov.pay.products.matchers.PaymentRequestMatcher;
+import uk.gov.pay.products.model.Payment;
+import uk.gov.pay.products.persistence.dao.PaymentDao;
+import uk.gov.pay.products.persistence.dao.ProductDao;
+import uk.gov.pay.products.persistence.entity.PaymentEntity;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+import uk.gov.pay.products.service.transaction.TransactionFlow;
+import uk.gov.pay.products.util.PaymentStatus;
+
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static uk.gov.pay.products.util.PaymentStatus.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaymentCreatorTest {
+
+    @Mock
+    private ProductDao productDao;
+
+    @Mock
+    private PaymentDao paymentDao;
+
+    @Mock
+    private PublicApiRestClient publicApiRestClient;
+
+    private PaymentCreator paymentCreator;
+
+    @Before
+    public void setup() throws Exception {
+        LinksDecorator linksDecorator = new LinksDecorator("https://products.url", "https://products-ui.url");
+        paymentCreator = new PaymentCreator(TransactionFlow::new, productDao, paymentDao, publicApiRestClient, linksDecorator);
+    }
+
+    @Test
+    public void shouldCreateASuccessfulPayment() throws Exception {
+        int productId = 1;
+        String productExternalId = "product-external-id";
+        long productPrice = 100l;
+        String productDescription = "description";
+        String productReturnUrl = "https://return.url";
+
+        String paymentId = "payment-id";
+        String paymentNextUrl = "http://next.url";
+
+        ProductEntity productEntity = createProductEntity(
+                productId,
+                productPrice,
+                productExternalId,
+                productDescription,
+                productReturnUrl);
+        PaymentRequest expectedPaymentRequest = createPaymentRequest(
+                productPrice,
+                productExternalId,
+                productDescription,
+                productReturnUrl);
+        PaymentResponse paymentResponse = createPaymentResponse(
+                paymentId,
+                paymentNextUrl);
+
+
+        when(productDao.findById(productId)).thenReturn(Optional.of(productEntity));
+        when(publicApiRestClient.createPayment(argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest)))).thenReturn(paymentResponse);
+
+        Payment payment = paymentCreator.doCreate(productId);
+
+        assertNotNull(payment);
+        assertNotNull(payment.getExternalId());
+        assertThat(payment.getGovukPaymentId(), is(paymentResponse.getPaymentId()));
+        assertThat(payment.getNextUrl(), is(paymentResponse.getLinks().getNextUrl().getHref()));
+        assertThat(payment.getProductId(), is(productEntity.getId()));
+        assertThat(payment.getProductExternalId(), is(productEntity.getExternalId()));
+        assertThat(payment.getStatus(), is(SUCCESS));
+
+        PaymentEntity expectedPaymentEntity = createPaymentEntity(
+                paymentId,
+                paymentNextUrl,
+                productEntity,
+                SUCCESS);
+        verify(paymentDao).merge(argThat(PaymentEntityMatcher.isSame(expectedPaymentEntity)));
+    }
+
+    @Test
+    public void shouldCreateAnErrorPayment_whenPublicApiCallFails() throws Exception {
+        int productId = 1;
+
+        String productExternalId = "product-external-id";
+        long productPrice = 100l;
+        String productDescription = "description";
+        String productReturnUrl = "https://return.url";
+
+        ProductEntity productEntity = createProductEntity(
+                productId,
+                productPrice,
+                productExternalId,
+                productDescription,
+                productReturnUrl);
+        PaymentRequest expectedPaymentRequest = createPaymentRequest(
+                productPrice,
+                productExternalId,
+                productDescription,
+                productReturnUrl);
+
+        when(productDao.findById(productId)).thenReturn(Optional.of(productEntity));
+        when(publicApiRestClient.createPayment(argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest))))
+                .thenThrow(PublicApiResponseErrorException.class);
+
+        try {
+            Payment payment = paymentCreator.doCreate(productId);
+            paymentCreator.doCreate(productId);
+            fail("Expected an PaymentCreatorDownstreamException to be thrown");
+        } catch (PaymentCreatorDownstreamException e) {
+            assertThat(e.getProductId(), is(productId));
+            PaymentEntity expectedPaymentEntity = createPaymentEntity(
+                    null,
+                    null,
+                    productEntity,
+                    ERROR);
+            verify(paymentDao).merge(argThat(PaymentEntityMatcher.isSame(expectedPaymentEntity)));
+        }
+    }
+
+    @Test
+    public void shouldThrowPaymentCreatorNotFoundException_whenProductIsNotFound() throws Exception {
+        int productId = 1;
+
+        when(productDao.findById(productId)).thenReturn(Optional.empty());
+
+        try {
+            paymentCreator.doCreate(productId);
+            fail("Expected an PaymentCreatorNotFoundException to be thrown");
+        } catch (PaymentCreatorNotFoundException e) {
+            assertThat(e.getProductId(), is(productId));
+        }
+
+    }
+
+
+    private ProductEntity createProductEntity(int id, long price, String externalId, String description, String returnUrl) {
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setId(id);
+        productEntity.setPrice(price);
+        productEntity.setExternalId(externalId);
+        productEntity.setDescription(description);
+        productEntity.setReturnUrl(returnUrl);
+
+        return productEntity;
+    }
+
+    private PaymentResponse createPaymentResponse(String id, String link) {
+        Links links = new Links();
+        links.setNextUrl(new Link(link, "GET", "multipart/form-data"));
+        PaymentResponse paymentResponse = new PaymentResponse();
+        paymentResponse.setPaymentId(id);
+        paymentResponse.setLinks(links);
+
+        return paymentResponse;
+    }
+
+    private PaymentRequest createPaymentRequest(long price, String externalId, String description, String returnUrl) {
+        return new PaymentRequest(price, externalId, description, returnUrl);
+    }
+
+    private PaymentEntity createPaymentEntity(String paymentId, String nextUrl, ProductEntity productEntity, PaymentStatus status) {
+        PaymentEntity paymentEntity = new PaymentEntity();
+        paymentEntity.setGovukPaymentId(paymentId);
+        paymentEntity.setNextUrl(nextUrl);
+        paymentEntity.setProductEntity(productEntity);
+        paymentEntity.setStatus(status);
+        return paymentEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
@@ -26,7 +26,7 @@ public class ProductCreatorTest {
 
     @Mock
     private ProductDao productDao;
-    private ProductCreator productsCreator;
+    private ProductCreator productCreator;
     @Captor
     private ArgumentCaptor<ProductEntity> persistedProductEntity;
     private String payApiToken;
@@ -37,7 +37,7 @@ public class ProductCreatorTest {
     @Before
     public void setup() throws Exception {
         LinksDecorator linksDecorator = new LinksDecorator("http://localhost", "http://localhost/pay");
-        productsCreator = new ProductCreator(productDao, linksDecorator);
+        productCreator = new ProductCreator(productDao, linksDecorator);
         gatewayAccountId = randomInt();
         payApiToken = randomUuid();
     }
@@ -55,7 +55,7 @@ public class ProductCreatorTest {
                 null
         );
 
-        Product product = productsCreator.doCreate(basicProduct);
+        Product product = productCreator.doCreate(basicProduct);
         assertThat(product.getName(), is("Test product name"));
         assertThat(product.getPrice(), is(1050L));
         assertThat(product.getPayApiToken(), is(payApiToken));
@@ -89,7 +89,7 @@ public class ProductCreatorTest {
                 returnUrl
         );
 
-        Product product = productsCreator.doCreate(productRequest);
+        Product product = productCreator.doCreate(productRequest);
         assertThat(product.getDescription(), is(description));
         assertThat(product.getReturnUrl(), is(returnUrl));
 

--- a/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
@@ -22,11 +22,11 @@ import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ProductsCreatorTest {
+public class ProductCreatorTest {
 
     @Mock
     private ProductDao productDao;
-    private ProductsCreator productsCreator;
+    private ProductCreator productsCreator;
     @Captor
     private ArgumentCaptor<ProductEntity> persistedProductEntity;
     private String payApiToken;
@@ -37,7 +37,7 @@ public class ProductsCreatorTest {
     @Before
     public void setup() throws Exception {
         LinksDecorator linksDecorator = new LinksDecorator("http://localhost", "http://localhost/pay");
-        productsCreator = new ProductsCreator(productDao, linksDecorator);
+        productsCreator = new ProductCreator(productDao, linksDecorator);
         gatewayAccountId = randomInt();
         payApiToken = randomUuid();
     }


### PR DESCRIPTION
# WHAT

`PaymentCreator` service takes care of all concerns regarding the creation of a new payment for a given product. The sole entry point of the service `doCreate` expects the `id` of a product for which a new payment will be created and returned.

1. The initial pre-operation step looks up the product and adds to it an empty payment with the status of `CREATED`. If the product doesn't exist a `PaymentCreatorNotFoundException` is thrown.

2. The actual operation then submits a payment creation request to PublicAPI which maps the outcome to our `PaymentEntity`. The status is updated to either `SUCCESS` or `ERROR` depending on whether the request is successful or not.

3. Finally the post-operation saves the payment updates. If the payment operation fails an `PaymentCreatorDownstreamException` is thrown.
