### PR TITLE
PP-2672 Renamed `productUiUrl` to `productUiPayUrl`

### DIFF
--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -29,7 +29,7 @@ public class ProductsConfiguration extends Configuration {
     private String publicApiUrl;
 
     @NotNull
-    private String productsUiUrl;
+    private String productsUiPayUrl;
 
     private String productsApiToken;
     private String productsApiToken2;
@@ -70,8 +70,8 @@ public class ProductsConfiguration extends Configuration {
         return publicApiUrl;
     }
 
-    public String getProductsUiUrl() {
-        return productsUiUrl;
+    public String getProductsUiPayUrl() {
+        return productsUiPayUrl;
     }
 
     public String getProductsApiToken() {

--- a/src/main/java/uk/gov/pay/products/config/ProductsModule.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsModule.java
@@ -41,7 +41,7 @@ public class ProductsModule extends AbstractModule {
         bind(ProductRequestValidator.class).in(Singleton.class);
         bind(LinksDecorator.class).toInstance(
                 new LinksDecorator(
-                        configuration.getBaseUrl(), configuration.getProductsUiUrl()));
+                        configuration.getBaseUrl(), configuration.getProductsUiPayUrl()));
         bind(ProductFinder.class).in(Singleton.class);
         bind(PaymentFinder.class).in(Singleton.class);
 

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
@@ -80,13 +80,13 @@ public class ProductResourceTest extends IntegrationTest {
         String externalId = response.extract().path(EXTERNAL_ID);
 
         String productsUrl = "https://products.url/v1/api/products/";
-        String productsUIUrl = "https://products-ui.url/";
+        String productsUIPayUrl = "https://products-ui.url/pay/";
         response
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern(productsUrl + externalId))
                 .body("_links[0].method", is(HttpMethod.GET))
                 .body("_links[0].rel", is("self"))
-                .body("_links[1].href", matchesPattern(productsUIUrl + externalId))
+                .body("_links[1].href", matchesPattern(productsUIPayUrl + externalId))
                 .body("_links[1].method", is(HttpMethod.POST))
                 .body("_links[1].rel", is("pay"));
 
@@ -129,13 +129,13 @@ public class ProductResourceTest extends IntegrationTest {
         String externalId = response.extract().path(EXTERNAL_ID);
 
         String productsUrl = "https://products.url/v1/api/products/";
-        String productsUIUrl = "https://products-ui.url/";
+        String productsUIPayUrl = "https://products-ui.url/pay/";
         response
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern(productsUrl + externalId))
                 .body("_links[0].method", is(HttpMethod.GET))
                 .body("_links[0].rel", is("self"))
-                .body("_links[1].href", matchesPattern(productsUIUrl + externalId))
+                .body("_links[1].href", matchesPattern(productsUIPayUrl + externalId))
                 .body("_links[1].method", is(HttpMethod.POST))
                 .body("_links[1].rel", is("pay"));
 
@@ -183,13 +183,13 @@ public class ProductResourceTest extends IntegrationTest {
                 .body(RETURN_URL, is(product.getReturnUrl()));
 
         String productsUrl = "https://products.url/v1/api/products/";
-        String productsUIUrl = "https://products-ui.url/";
+        String productsUIPayUrl = "https://products-ui.url/pay/";
         response
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern(productsUrl + externalId))
                 .body("_links[0].method", is(HttpMethod.GET))
                 .body("_links[0].rel", is("self"))
-                .body("_links[1].href", matchesPattern(productsUIUrl + externalId))
+                .body("_links[1].href", matchesPattern(productsUIPayUrl + externalId))
                 .body("_links[1].method", is(HttpMethod.POST))
                 .body("_links[1].rel", is("pay"));
     }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -63,6 +63,6 @@ jerseyClientConfiguration:
 
 baseUrl: https://products.url
 publicApiUrl: https://publicapi.url
-productsUiUrl: https://products-ui.url
+productsUiPayUrl: https://products-ui.url/pay
 
 productsApiToken: default-local-api-token


### PR DESCRIPTION
#WHAT 
This config name change is to make it more explicit that the URL expected here is not the Product UI base URL but the full URL to the paying resource.