### PR TITLE
PP-2672 Improved version of `PublicApiRestClient` taking into account the `Bearer` API token

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiRestClient.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiRestClient.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 
 public class PublicApiRestClient {
     private static final Logger logger = LoggerFactory.getLogger(PublicApiRestClient.class);
@@ -31,12 +32,13 @@ public class PublicApiRestClient {
         this.publicApiUrl = publicApiUrl;
     }
 
-    public PaymentResponse createPayment(PaymentRequest paymentRequest) {
+    public PaymentResponse createPayment(String apiToken, PaymentRequest paymentRequest) {
         logger.info("Public API client requested creation of payment - [ {} ]", paymentRequest);
 
         Response response = client
                 .target(buildAbsoluteUrl(PAYMENTS_PATH))
                 .request()
+                .header(AUTHORIZATION, constructBearerToken(apiToken))
                 .post(Entity.entity(paymentRequest, MediaType.APPLICATION_JSON));
 
         if (response.getStatus() == HttpStatus.CREATED_201) {
@@ -50,12 +52,13 @@ public class PublicApiRestClient {
         throw publicApiResponseErrorException;
     }
 
-    public Optional<PaymentResponse> getPayment(String paymentId) {
+    public Optional<PaymentResponse> getPayment(String apiToken, String paymentId) {
         logger.info("Public API client requested finding payment - [ {} ]", paymentId);
 
         Response response = client
                 .target(buildAbsoluteUrl(format(PAYMENT_PATH, paymentId)))
                 .request()
+                .header(AUTHORIZATION, constructBearerToken(apiToken))
                 .get();
 
         if (response.getStatus() == HttpStatus.OK_200) {
@@ -79,6 +82,10 @@ public class PublicApiRestClient {
                 .fromPath(publicApiUrl)
                 .path(relativeUrl)
                 .toString();
+    }
+
+    private String constructBearerToken(String apiToken) {
+        return "Bearer " + apiToken;
     }
 
 }

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -85,7 +85,7 @@ public class PaymentCreator {
                     productEntity.getReturnUrl());
 
             try {
-                PaymentResponse paymentResponse = publicApiRestClient.createPayment(paymentRequest);
+                PaymentResponse paymentResponse = publicApiRestClient.createPayment(productEntity.getPayApiToken(), paymentRequest);
 
                 paymentEntity.setGovukPaymentId(paymentResponse.getPaymentId());
                 paymentEntity.setNextUrl(getNextUrl(paymentResponse));

--- a/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
@@ -65,7 +65,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 product.getReturnUrl(),
                 nextUrl);
         publicApiStub
-                .whenReceiveCreatedPaymentRequestWithBody(expectedPaymentRequestPayload)
+                .whenReceiveCreatedPaymentRequestWithAuthApiTokenAndWithBody(product.getPayApiToken(), expectedPaymentRequestPayload)
                 .respondCreatedWithBody(paymentResponsePayload);
 
         ValidatableResponse response = givenAuthenticatedSetup()
@@ -143,7 +143,7 @@ public class PaymentResourceTest extends IntegrationTest {
         JsonObject errorPayload = PublicApiStub.createErrorPayload();
 
         publicApiStub
-                .whenReceiveCreatedPaymentRequestWithBody(expectedPaymentRequestPayload)
+                .whenReceiveCreatedPaymentRequestWithAuthApiTokenAndWithBody(product.getPayApiToken(), expectedPaymentRequestPayload)
                 .respondBadRequestWithBody(errorPayload);
 
         givenAuthenticatedSetup()

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.products.service;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.products.client.publicapi.PaymentRequest;
@@ -64,6 +65,7 @@ public class PaymentCreatorTest {
         long productPrice = 100L;
         String productDescription = "description";
         String productReturnUrl = "https://return.url";
+        String productApiToken = "api-token";
 
         String paymentId = "payment-id";
         Long paymentAmount = 50L;
@@ -74,7 +76,8 @@ public class PaymentCreatorTest {
                 productPrice,
                 productExternalId,
                 productDescription,
-                productReturnUrl);
+                productReturnUrl,
+                productApiToken);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 productPrice,
                 productExternalId,
@@ -87,7 +90,7 @@ public class PaymentCreatorTest {
 
 
         when(productDao.findByExternalId(productExternalId)).thenReturn(Optional.of(productEntity));
-        when(publicApiRestClient.createPayment(argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest)))).thenReturn(paymentResponse);
+        when(publicApiRestClient.createPayment(argThat(is(productApiToken)), argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest)))).thenReturn(paymentResponse);
 
         Payment payment = paymentCreator.doCreate(productExternalId);
 
@@ -122,13 +125,16 @@ public class PaymentCreatorTest {
         long productPrice = 100L;
         String productDescription = "description";
         String productReturnUrl = "https://return.url";
+        String productApiToken = "api-token";
+
 
         ProductEntity productEntity = createProductEntity(
                 productId,
                 productPrice,
                 productExternalId,
                 productDescription,
-                productReturnUrl);
+                productReturnUrl,
+                productApiToken);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 productPrice,
                 productExternalId,
@@ -136,7 +142,7 @@ public class PaymentCreatorTest {
                 productReturnUrl);
 
         when(productDao.findByExternalId(productExternalId)).thenReturn(Optional.of(productEntity));
-        when(publicApiRestClient.createPayment(argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest))))
+        when(publicApiRestClient.createPayment(argThat(is(productApiToken)), argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest))))
                 .thenThrow(PublicApiResponseErrorException.class);
 
         try {
@@ -170,13 +176,14 @@ public class PaymentCreatorTest {
     }
 
 
-    private ProductEntity createProductEntity(int id, long price, String externalId, String description, String returnUrl) {
+    private ProductEntity createProductEntity(int id, long price, String externalId, String description, String returnUrl, String apiToken) {
         ProductEntity productEntity = new ProductEntity();
         productEntity.setId(id);
         productEntity.setPrice(price);
         productEntity.setExternalId(externalId);
         productEntity.setDescription(description);
         productEntity.setReturnUrl(returnUrl);
+        productEntity.setPayApiToken(apiToken);
 
         return productEntity;
     }

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
@@ -8,6 +8,7 @@ import javax.json.JsonObject;
 import static java.lang.String.format;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.mockserver.model.HttpRequest.request;
@@ -110,10 +111,11 @@ public class PublicApiStub {
                 .build();
     }
 
-    public PublicApiStubExpectation whenReceiveCreatedPaymentRequestWithBody(JsonObject requestBody) {
+    public PublicApiStubExpectation whenReceiveCreatedPaymentRequestWithAuthApiTokenAndWithBody(String authApiToken, JsonObject requestBody) {
         return new PublicApiStubExpectation(mockClient.when(request()
                 .withMethod(POST)
                 .withPath(PAYMENTS_PATH)
+                .withHeader(AUTHORIZATION, "Bearer " + authApiToken)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                 .withBody(requestBody.toString())));
     }

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStubExpectation.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStubExpectation.java
@@ -1,15 +1,13 @@
 package uk.gov.pay.products.stubs.publicapi;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.mockserver.client.server.ForwardChainExpectation;
 
 import javax.json.JsonObject;
 
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
-import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
-import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
-import static org.eclipse.jetty.http.HttpStatus.OK_200;
+import static org.eclipse.jetty.http.HttpStatus.*;
 import static org.mockserver.model.HttpResponse.response;
 
 public class PublicApiStubExpectation {
@@ -44,6 +42,12 @@ public class PublicApiStubExpectation {
     public void respondNotFound() {
         expectation.respond(response()
                 .withStatusCode(NOT_FOUND_404)
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON));
+    }
+
+    public void respondUnauthorized() {
+        expectation.respond(response()
+                .withStatusCode(UNAUTHORIZED_401)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON));
     }
 }


### PR DESCRIPTION
# WHAT

Improved version of `PublicApiRestClient` taking into account the `Bearer` API token that needs to be passed in the header of all PublicAPI requests for obvious security reasons. The authorization token is in the form of `Bearer + API token` where the API token is specific for each product.