### PR TITLE
PP-2855 add end2end test step for builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,11 @@ pipeline {
         }
       }
     }
+    stage('Test') {
+      steps {
+        runParameterisedEndToEnd("products", null, "end2end-products", false, false)
+      }
+    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
Triggering `runParameterisedEndToEnd` with the test profile `end2end-products`. It also disables the accept tests and zap tests