### PR TITLE
PP-2672 Change payment status enum from SUCCESS to SUBMITTED

### DIFF
--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -100,7 +100,7 @@ public class PaymentCreator {
 
                 paymentEntity.setGovukPaymentId(paymentResponse.getPaymentId());
                 paymentEntity.setNextUrl(getNextUrl(paymentResponse));
-                paymentEntity.setStatus(PaymentStatus.SUCCESS);
+                paymentEntity.setStatus(PaymentStatus.SUBMITTED);
                 paymentEntity.setAmount(paymentResponse.getAmount());
                 logger.info("Payment creation for product external id {} successful {}", paymentEntity.getProductEntity().getExternalId(), paymentEntity);
             } catch (PublicApiResponseErrorException e) {

--- a/src/main/java/uk/gov/pay/products/util/PaymentStatus.java
+++ b/src/main/java/uk/gov/pay/products/util/PaymentStatus.java
@@ -6,6 +6,6 @@ package uk.gov.pay.products.util;
 
 public enum PaymentStatus {
     CREATED,
-    SUCCESS,
+    SUBMITTED,
     ERROR
 }

--- a/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
@@ -85,7 +85,7 @@ public class PaymentResourceTest extends IntegrationTest {
         assertThat(paymentRecords.get(0), hasEntry("govuk_payment_id", govukPaymentId));
         assertThat(paymentRecords.get(0), hasKey("product_id"));
         assertThat(paymentRecords.get(0), hasEntry("next_url", nextUrl));
-        assertThat(paymentRecords.get(0), hasEntry("status", "SUCCESS"));
+        assertThat(paymentRecords.get(0), hasEntry("status", "SUBMITTED"));
         assertThat(paymentRecords.get(0), hasEntry("amount", product.getPrice()));
         assertThat(paymentRecords.get(0), hasKey("date_created"));
 
@@ -93,7 +93,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 .body("external_id", is(paymentExternalId))
                 .body("govuk_payment_id", is(govukPaymentId))
                 .body("product_external_id", is(product.getExternalId()))
-                .body("status", is("SUCCESS"))
+                .body("status", is("SUBMITTED"))
                 .body("amount", is(product.getPrice().intValue()))
                 .body("_links", hasSize(2))
                 .body("_links[0].href", matchesPattern(paymentsUrl + paymentExternalId))

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.gov.pay.products.util.PaymentStatus.ERROR;
-import static uk.gov.pay.products.util.PaymentStatus.SUCCESS;
+import static uk.gov.pay.products.util.PaymentStatus.SUBMITTED;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(RandomIdGenerator.class)
@@ -115,13 +115,13 @@ public class PaymentCreatorTest {
         assertThat(payment.getLinks().get(1).getHref(), is(paymentResponse.getLinks().getNextUrl().getHref()));
         assertThat(payment.getProductId(), is(productEntity.getId()));
         assertThat(payment.getProductExternalId(), is(productEntity.getExternalId()));
-        assertThat(payment.getStatus(), is(SUCCESS));
+        assertThat(payment.getStatus(), is(SUBMITTED));
 
         PaymentEntity expectedPaymentEntity = createPaymentEntity(
                 paymentId,
                 paymentNextUrl,
                 productEntity,
-                SUCCESS,
+                SUBMITTED,
                 paymentAmount);
         verify(paymentDao).merge(argThat(PaymentEntityMatcher.isSame(expectedPaymentEntity)));
     }
@@ -181,13 +181,13 @@ public class PaymentCreatorTest {
         assertThat(payment.getLinks().get(1).getHref(), is(paymentResponse.getLinks().getNextUrl().getHref()));
         assertThat(payment.getProductId(), is(productEntity.getId()));
         assertThat(payment.getProductExternalId(), is(productEntity.getExternalId()));
-        assertThat(payment.getStatus(), is(SUCCESS));
+        assertThat(payment.getStatus(), is(SUBMITTED));
 
         PaymentEntity expectedPaymentEntity = createPaymentEntity(
                 paymentId,
                 paymentNextUrl,
                 productEntity,
-                SUCCESS,
+                SUBMITTED,
                 paymentAmount);
         verify(paymentDao).merge(argThat(PaymentEntityMatcher.isSame(expectedPaymentEntity)));
     }


### PR DESCRIPTION
## WHAT

- change the payment status enum from 'SUCCESS' to 'SUBMITTED'

## WHY
Currently we mark a payment status `SUCCESS` when a charge was successfully created on publicapi. This leads to confusion as the actual payment might not be successful at all. To avoid the confusion we mark it as `SUBMITTED`.
At a later point we will reintroduce `SUCCESS` to cache the status of a payment.

