### PR TITLE
PP-2672 Bugfix: Setup Guice injector to bind `ProductsConfiguration` as a depency

### DIFF
--- a/src/main/java/uk/gov/pay/products/config/ProductsModule.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsModule.java
@@ -34,6 +34,7 @@ public class ProductsModule extends AbstractModule {
     protected void configure() {
         final Client client = RestClientFactory.buildClient(configuration.getRestClientConfiguration());
 
+        bind(ProductsConfiguration.class).toInstance(configuration);
         bind(DataSourceFactory.class).toInstance(configuration.getDataSourceFactory());
         bind(MetricRegistry.class).toInstance(environment.metrics());
         bind(Environment.class).toInstance(environment);


### PR DESCRIPTION
# WHAT
`PaymentCreator` service had a dependency with `ProductsConfiguration` which could never be resolved because `Guice` injector didn't have the dependency explicitly bound to it.