### PR TITLE
PP-2959 Explicit docker pull postgres image for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>
         <powermock.version>1.7.3</powermock.version>
+        <docker-client.version>8.9.2</docker-client.version>
     </properties>
 
     <dependencyManagement>
@@ -144,7 +145,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>8.9.0</version>
+            <version>${docker-client.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/products/infra/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/products/infra/PostgresContainer.java
@@ -32,10 +32,10 @@ public class PostgresContainer {
     private String host;
     private volatile boolean stopped = false;
 
+    private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
     private static final String DB_PASSWORD = "mysecretpassword";
     private static final String DB_USERNAME = "postgres";
     private static final int DB_TIMEOUT_SEC = 15;
-    private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
     private static final String INTERNAL_PORT = "5432";
 
     public PostgresContainer(DockerClient docker, String host) throws InterruptedException, IOException, ClassNotFoundException, DockerException {
@@ -44,6 +44,7 @@ public class PostgresContainer {
         this.docker = docker;
         this.host = host;
 
+        failsafeDockerPull(docker, GOVUK_POSTGRES_IMAGE);
         docker.listImages(DockerClient.ListImagesParam.create("name", GOVUK_POSTGRES_IMAGE));
 
         final HostConfig hostConfig = HostConfig.builder().logConfig(LogConfig.create("json-file")).publishAllPorts(true).build();
@@ -69,6 +70,14 @@ public class PostgresContainer {
 
     public String getConnectionUrl() {
         return "jdbc:postgresql://" + host + ":" + port + "/";
+    }
+
+    private void failsafeDockerPull(DockerClient docker, String image) {
+        try {
+            docker.pull(image);
+        } catch (Exception e) {
+            logger.error("Docker image " + image + " could not be pulled from DockerHub", e);
+        }
     }
 
     private static int hostPortNumber(ContainerInfo containerInfo) {


### PR DESCRIPTION
## WHAT

- Current integration tests are using a non ideal manually built Postgres image for testing. Even less ideal is pulling the image locally when it does not exist (example as in new machines, docker images clean up, changed a reference to a new image)

- Pull explicitly the docker image before running the tests

- Upgrade docker-client (test scope) version from 8.1.0 -> 8.9.2