### PR TITLE
PP-2923 migrating to end2end-tagged maven test profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     }
     stage('Test') {
       steps {
-        runParameterisedEndToEnd("products", null, "end2end-products", false, false)
+        runParameterisedEndToEnd("products", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndProducts")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
Moving away from having required to declare specific maven profiles for various category of end2end builds. `end2end-tagged` profile is generic enough to run any kind of test groups with necessary includes and excludes. This moves the products to use the `end2end-tagged` profile.