### PR TITLE
PP-2916 adding mandatory dependency as a top level dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,13 +106,18 @@
             <version>${guice.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+
+        <!-- testing -->
+        <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>


### PR DESCRIPTION
This is required for DBHostnameVerifier check on postgres connection.