### PR TITLE
PP-2925 add proxy configuration for products

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
   agent any
 
   options {
-    ansiColor('xterm')
     timestamps()
   }
 

--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -21,6 +21,7 @@ import uk.gov.pay.products.auth.TokenAuthenticator;
 import uk.gov.pay.products.config.PersistenceServiceInitialiser;
 import uk.gov.pay.products.config.ProductsConfiguration;
 import uk.gov.pay.products.config.ProductsModule;
+import uk.gov.pay.products.config.ProxyConfiguration;
 import uk.gov.pay.products.exception.mapper.PaymentCreationExceptionMapper;
 import uk.gov.pay.products.exception.mapper.PaymentCreatorNotFoundExceptionMapper;
 import uk.gov.pay.products.filters.LoggingFilter;
@@ -92,12 +93,18 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
 
         attachExceptionMappersTo(environment.jersey());
 
-        setGlobalProxies();
+        setGlobalProxies(configuration);
     }
 
-    private void setGlobalProxies() {
+    private void setGlobalProxies(ProductsConfiguration configuration) {
         SSLSocketFactory socketFactory = new TrustingSSLSocketFactory();
         HttpsURLConnection.setDefaultSSLSocketFactory(socketFactory);
+
+        ProxyConfiguration proxyConfiguration = configuration.getProxyConfiguration();
+        if (proxyConfiguration.getEnabled()) {
+            System.setProperty("https.proxyHost", proxyConfiguration.getHost());
+            System.setProperty("https.proxyPort", proxyConfiguration.getPort().toString());
+        }
     }
 
     private void initialiseMetrics(ProductsConfiguration configuration, Environment environment) {

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -48,6 +48,11 @@ public class ProductsConfiguration extends Configuration {
     @JsonProperty("jerseyClientConfiguration")
     private RestClientConfiguration restClientConfiguration;
 
+    @Valid
+    @NotNull
+    @JsonProperty("proxy")
+    private ProxyConfiguration proxyConfiguration;
+
     public String getGraphiteHost() {
         return graphiteHost;
     }
@@ -91,5 +96,9 @@ public class ProductsConfiguration extends Configuration {
     }
 
     public String getProductsUiConfirmUrl() { return productsUiConfirmUrl;
+    }
+
+    public ProxyConfiguration getProxyConfiguration() {
+        return proxyConfiguration;
     }
 }

--- a/src/main/java/uk/gov/pay/products/config/ProxyConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProxyConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.products.config;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.constraints.NotNull;
+
+public class ProxyConfiguration extends Configuration {
+
+    @NotNull
+    private String host;
+
+    @NotNull
+    private Integer port;
+
+    @NotNull
+    private String enabled;
+
+    public String getHost() {
+        return host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public boolean getEnabled() {
+        return Boolean.valueOf(enabled);
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -51,6 +51,11 @@ database:
   # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
   minIdleTime: 1 minute
 
+proxy:
+  enabled: ${HTTP_PROXY_ENABLED:-true}
+  host: ${HTTP_PROXY_HOST}
+  port: ${HTTP_PROXY_PORT}
+
 jpa:
   jpaLoggingLevel: ${JPA_LOG_LEVEL:-WARNING}
   sqlLoggingLevel: ${JPA_SQL_LOG_LEVEL:-WARNING}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -51,6 +51,11 @@ database:
   # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
   minIdleTime: 1 minute
 
+proxy:
+  enabled: false
+  host: localhost
+  port: 1234
+
 jpa:
   jpaLoggingLevel: ${JPA_LOG_LEVEL:-WARNING}
   sqlLoggingLevel: ${JPA_SQL_LOG_LEVEL:-WARNING}


### PR DESCRIPTION
We now need this as we are in AWS as all outbound comms needs to be via the proxy.
Adding an extra config param `enabled` just to make sure we have a mechanism of disabling it in PaaS (until we stick with PaaS, then we can remove this condition)