### PR TITLE
PP-2996 Trigger products to deploy both on PaaS as well as AWS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
       }
       steps {
         deployPaas("products", "test", null, true)
+        deploy("products", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeProducts")
       }
     }
   }


### PR DESCRIPTION
This needs to be done until we fully migrate over to AWS.