### PR TITLE
PP-2996 disable smoke test on AWS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
       }
       steps {
         deployPaas("products", "test", null, true)
-        deploy("products", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeProducts")
+        deploy("products", "test", null, true, false, "uk.gov.pay.endtoend.categories.SmokeProducts")
       }
     }
   }


### PR DESCRIPTION
Until the selfservice CNAME issue (PROMOTED_ENV and PUBLIC_ENV var) fixed on CI and DEPLOY.