### PR TITLE
PP-3031 Add Random Reference Number changes to entity

### DIFF
--- a/src/main/java/uk/gov/pay/products/model/Payment.java
+++ b/src/main/java/uk/gov/pay/products/model/Payment.java
@@ -22,6 +22,7 @@ public class Payment {
     private static final String FIELD_STATUS = "status";
     private static final String FIELD_AMOUNT = "amount";
     private static final String FIELD_GOVUK_STATUS = "govuk_status";
+    private static final String FIELD_REFERENCE_NUMBER = "reference_number";
 
     private String externalId;
     private String govukPaymentId;
@@ -34,6 +35,9 @@ public class Payment {
     private Long amount;
     @JsonProperty(FIELD_GOVUK_STATUS)
     private String govUkStatus;
+    @JsonIgnore
+    private Integer gatewayAccountId;
+    private String referenceNumber;
 
     private PaymentStatus status;
 
@@ -44,7 +48,9 @@ public class Payment {
             @JsonProperty(FIELD_AMOUNT) Long amount,
             @JsonProperty(FIELD_PRODUCT_EXTERNAL_ID) String productExternalId,
             @JsonProperty(FIELD_STATUS) PaymentStatus status,
-            Integer productId) {
+            Integer productId,
+            Integer gatewayAccountId,
+            @JsonProperty(FIELD_REFERENCE_NUMBER) String referenceNumber) {
         this.externalId = externalId;
         this.govukPaymentId = govukPaymentId;
         this.nextUrl = nextUrl;
@@ -52,6 +58,8 @@ public class Payment {
         this.status = status;
         this.productId = productId;
         this.amount = amount;
+        this.gatewayAccountId = gatewayAccountId;
+        this.referenceNumber = referenceNumber;
     }
 
     public String getExternalId() {
@@ -101,5 +109,13 @@ public class Payment {
 
     public void setGovukStatus(String status){
         this.govUkStatus = status;
+    }
+
+    public Integer getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getReferenceNumber() {
+        return referenceNumber;
     }
 }

--- a/src/main/java/uk/gov/pay/products/model/Payment.java
+++ b/src/main/java/uk/gov/pay/products/model/Payment.java
@@ -35,8 +35,6 @@ public class Payment {
     private Long amount;
     @JsonProperty(FIELD_GOVUK_STATUS)
     private String govUkStatus;
-    @JsonIgnore
-    private Integer gatewayAccountId;
     private String referenceNumber;
 
     private PaymentStatus status;
@@ -49,7 +47,6 @@ public class Payment {
             @JsonProperty(FIELD_PRODUCT_EXTERNAL_ID) String productExternalId,
             @JsonProperty(FIELD_STATUS) PaymentStatus status,
             Integer productId,
-            Integer gatewayAccountId,
             @JsonProperty(FIELD_REFERENCE_NUMBER) String referenceNumber) {
         this.externalId = externalId;
         this.govukPaymentId = govukPaymentId;
@@ -58,7 +55,6 @@ public class Payment {
         this.status = status;
         this.productId = productId;
         this.amount = amount;
-        this.gatewayAccountId = gatewayAccountId;
         this.referenceNumber = referenceNumber;
     }
 
@@ -109,10 +105,6 @@ public class Payment {
 
     public void setGovukStatus(String status){
         this.govUkStatus = status;
-    }
-
-    public Integer getGatewayAccountId() {
-        return gatewayAccountId;
     }
 
     public String getReferenceNumber() {

--- a/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
@@ -43,6 +43,12 @@ public class PaymentEntity extends AbstractEntity {
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 
+    @Column(name = "gateway_account_id")
+    private Integer gatewayAccountId;
+
+    @Column(name = "reference_number")
+    private String referenceNumber;
+
     public PaymentEntity() {
     }
 
@@ -106,7 +112,9 @@ public class PaymentEntity extends AbstractEntity {
                 this.getAmount(),
                 this.product != null ? this.product.getExternalId() : null,
                 this.status,
-                this.product != null ? this.product.getId() : null
+                this.product != null ? this.product.getId() : null,
+                this.getGatewayAccountId(),
+                this.getReferenceNumber()
         );
     }
 
@@ -121,5 +129,21 @@ public class PaymentEntity extends AbstractEntity {
                 ", productEntity=" + product +
                 ", status=" + status +
                 '}';
+    }
+
+    public Integer getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public void setGatewayAccountId(Integer gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public String getReferenceNumber() {
+        return referenceNumber;
+    }
+
+    public void setReferenceNumber(String referenceNumber) {
+        this.referenceNumber = referenceNumber;
     }
 }

--- a/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
@@ -113,7 +113,6 @@ public class PaymentEntity extends AbstractEntity {
                 this.product != null ? this.product.getExternalId() : null,
                 this.status,
                 this.product != null ? this.product.getId() : null,
-                this.getGatewayAccountId(),
                 this.getReferenceNumber()
         );
     }

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -81,16 +81,17 @@ public class PaymentCreator {
             paymentEntity.setGatewayAccountId(productEntity.getGatewayAccountId());
             paymentEntity.setReferenceNumber(randomUserFriendlyReference());
 
-            AtomicInteger counter = new AtomicInteger(0);
+            int counter = 0;
             return mergePaymentEntityWithReferenceNumberCheck(paymentEntity, counter);
         };
     }
 
-    private PaymentEntity mergePaymentEntityWithReferenceNumberCheck(PaymentEntity paymentEntity, AtomicInteger counter) {
-        int count = counter.getAndIncrement();
+    private PaymentEntity mergePaymentEntityWithReferenceNumberCheck(PaymentEntity paymentEntity, int counter) {
+        int count = counter++;
         if(count == MAX_NUMBER_OF_RETRY_FOR_UNIQUE_REF_NUMBER) {
-            RuntimeException runtimeException = new RuntimeException("We have run out of random reference numbers");
-            logger.error("We have run out of random reference numbers", runtimeException);
+            String exceptionMsg = format("Too many conflicts generating unique user friendly reference numbers for gateway account %s", paymentEntity.getGatewayAccountId());
+            RuntimeException runtimeException = new RuntimeException(exceptionMsg);
+            logger.error(exceptionMsg, runtimeException);
             throw runtimeException;
         }
 

--- a/src/main/resources/migrations/00013_add_unique_two_column_constraint_to_payments.sql
+++ b/src/main/resources/migrations/00013_add_unique_two_column_constraint_to_payments.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_two_column_unique_constraint_on_payments
+ALTER TABLE payments ADD UNIQUE (gateway_account_id, reference_number);
+
+--rollback alter table payments drop unique (gateway_account_id, reference_number);

--- a/src/test/java/uk/gov/pay/products/fixtures/PaymentEntityFixture.java
+++ b/src/test/java/uk/gov/pay/products/fixtures/PaymentEntityFixture.java
@@ -16,6 +16,8 @@ public class PaymentEntityFixture {
     private ZonedDateTime dateCreated = ZonedDateTime.now();
     private PaymentStatus status = PaymentStatus.CREATED;
     private Long amount = 100L;
+    private Integer gatewayAccountId;
+    private String referenceNumber = "MXDRTEWR12";
 
     private ProductEntity productEntity;
 
@@ -32,6 +34,8 @@ public class PaymentEntityFixture {
         payment.setStatus(status);
         payment.setProductEntity(productEntity);
         payment.setAmount(amount);
+        payment.setGatewayAccountId(gatewayAccountId == null ? productEntity.getGatewayAccountId() : gatewayAccountId);
+        payment.setReferenceNumber(referenceNumber);
 
         return payment;
     }
@@ -72,6 +76,16 @@ public class PaymentEntityFixture {
 
     public PaymentEntityFixture withProduct(ProductEntity productEntity) {
         this.productEntity = productEntity;
+        return this;
+    }
+
+    public PaymentEntityFixture withGatewayAccountId(Integer gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+        return this;
+    }
+
+    public PaymentEntityFixture withReferenceNumber(String referenceNumber) {
+        this.referenceNumber = referenceNumber;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/products/persistence/dao/PaymentDaoTest.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/PaymentDaoTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
 public class PaymentDaoTest extends DaoTestBase {
@@ -45,7 +46,7 @@ public class PaymentDaoTest extends DaoTestBase {
                 .withProduct(productEntity)
                 .withReferenceNumber("MH2KJY5KPW")
                 .build();
-        databaseHelper.addPayment(payment.toPayment());
+        databaseHelper.addPayment(payment.toPayment(), 1);
 
         Optional<PaymentEntity> paymentEntity = paymentDao.findByExternalId(payment.getExternalId());
         assertTrue(paymentEntity.isPresent());
@@ -78,13 +79,14 @@ public class PaymentDaoTest extends DaoTestBase {
 
     @Test
     public void shouldSuccess_whenSearchingForPaymentsByProductId() throws Exception{
+        Integer gatewayAccountId = randomInt();
         PaymentEntity payment1 = PaymentEntityFixture.aPaymentEntity()
                 .withExternalId(randomUuid())
                 .withStatus(PaymentStatus.CREATED)
                 .withProduct(productEntity)
                 .withReferenceNumber("MH2KJY5KIY")
                 .build();
-        databaseHelper.addPayment(payment1.toPayment());
+        databaseHelper.addPayment(payment1.toPayment(), gatewayAccountId);
 
         PaymentEntity payment2 = PaymentEntityFixture.aPaymentEntity()
                 .withExternalId(randomUuid())
@@ -92,7 +94,7 @@ public class PaymentDaoTest extends DaoTestBase {
                 .withProduct(productEntity)
                 .withReferenceNumber("MH3JY6KIY")
                 .build();
-        databaseHelper.addPayment(payment2.toPayment());
+        databaseHelper.addPayment(payment2.toPayment(), gatewayAccountId);
 
         List<PaymentEntity> paymentEntities = paymentDao.findByProductExternalId(productEntity.getExternalId());
         assertFalse(paymentEntities.isEmpty());
@@ -120,19 +122,22 @@ public class PaymentDaoTest extends DaoTestBase {
     @Test
     public void shouldThrowExceptionOnMerge_whenSameGatewayAndReferenceNumber() {
         String referenceNumber = randomUuid().substring(1,10).toUpperCase();
+        Integer gatewayAccountId = randomInt();
         PaymentEntity payment1 = PaymentEntityFixture.aPaymentEntity()
                 .withExternalId(randomUuid())
                 .withStatus(PaymentStatus.CREATED)
                 .withProduct(productEntity)
                 .withReferenceNumber(referenceNumber)
+                .withGatewayAccountId(gatewayAccountId)
                 .build();
-        databaseHelper.addPayment(payment1.toPayment());
+        databaseHelper.addPayment(payment1.toPayment(), gatewayAccountId);
 
         PaymentEntity payment2 = PaymentEntityFixture.aPaymentEntity()
                 .withExternalId(randomUuid())
                 .withStatus(PaymentStatus.ERROR)
                 .withProduct(productEntity)
                 .withReferenceNumber(referenceNumber)
+                .withGatewayAccountId(gatewayAccountId)
                 .build();
 
         Exception exception = null;

--- a/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
@@ -200,7 +200,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 .withReferenceNumber(referenceNumber)
                 .build();
 
-        databaseHelper.addPayment(payment.toPayment());
+        databaseHelper.addPayment(payment.toPayment(), productEntity.getGatewayAccountId());
 
         ValidatableResponse response = givenAuthenticatedSetup()
                 .when()
@@ -271,7 +271,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 .withReferenceNumber(paymentExternalId1.substring(0, 9))
                 .build();
 
-        databaseHelper.addPayment(payment1.toPayment());
+        databaseHelper.addPayment(payment1.toPayment(), gatewayAccountId);
 
         PaymentEntity payment2 = PaymentEntityFixture.aPaymentEntity()
                 .withExternalId(paymentExternalId2)
@@ -280,7 +280,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 .withReferenceNumber(paymentExternalId2.substring(0, 9))
                 .build();
 
-        databaseHelper.addPayment(payment2.toPayment());
+        databaseHelper.addPayment(payment2.toPayment(), gatewayAccountId);
 
         ValidatableResponse response = givenAuthenticatedSetup()
                 .when()

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.products.service;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,10 +30,14 @@ import uk.gov.pay.products.util.RandomIdGenerator;
 
 import java.util.Optional;
 
+import static java.util.Objects.isNull;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -58,6 +63,8 @@ public class PaymentCreatorTest {
     private ProductsConfiguration productsConfiguration;
 
     private PaymentCreator paymentCreator;
+
+
 
     @Before
     public void setup() throws Exception {
@@ -249,6 +256,47 @@ public class PaymentCreatorTest {
 
     }
 
+    @Test
+    public void shouldThrowRuntimeException_whenRunOutOfReferenceNumbers() {
+        int productId = 1;
+        String productExternalId = "product-external-id";
+        long productPrice = 100L;
+        String productName = "name";
+        String productApiToken = "api-token";
+
+        Integer gatewayAccountId = 1;
+
+        ProductEntity productEntity = createProductEntity(
+                productId,
+                productPrice,
+                productExternalId,
+                productName,
+                "",
+                productApiToken,
+                gatewayAccountId);
+
+        when(productDao.findByExternalId(productExternalId)).thenReturn(Optional.of(productEntity));
+        doThrow(new javax.persistence.RollbackException("payments_gateway_account_id_reference_number_key duplicate key value violates unique constraint"))
+                .when(paymentDao).persist(any(PaymentEntity.class));
+
+        Exception exception = null;
+        try {
+            paymentCreator.doCreate(productExternalId);
+        } catch (RuntimeException ex) {
+            exception = ex;
+        }
+        assertThat(isNull(exception), is(false));
+        assertThat(exception instanceof RuntimeException, is(true));
+        assertThat(exception.getMessage().contains("We have run out of random reference numbers"), is(true));
+        verify(paymentDao, times(3)).persist(any(PaymentEntity.class));
+    }
+
+    private ProductEntity createProductEntity(int id, long price, String externalId, String name, String returnUrl, String apiToken, Integer gatewayAccountId) {
+        ProductEntity productEntity = createProductEntity(id, price, externalId, name, returnUrl,apiToken);
+        productEntity.setGatewayAccountId(gatewayAccountId);
+
+        return productEntity;
+    }
 
     private ProductEntity createProductEntity(int id, long price, String externalId, String name, String returnUrl, String apiToken) {
         ProductEntity productEntity = new ProductEntity();

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -257,7 +257,7 @@ public class PaymentCreatorTest {
     }
 
     @Test
-    public void shouldThrowRuntimeException_whenRunOutOfReferenceNumbers() {
+    public void shouldThrowRuntimeException_whenTooManyConflictsInReferenceNumbers() {
         int productId = 1;
         String productExternalId = "product-external-id";
         long productPrice = 100L;
@@ -287,7 +287,7 @@ public class PaymentCreatorTest {
         }
         assertThat(isNull(exception), is(false));
         assertThat(exception instanceof RuntimeException, is(true));
-        assertThat(exception.getMessage().contains("We have run out of random reference numbers"), is(true));
+        assertThat(exception.getMessage().contains("Too many conflicts generating unique user friendly reference numbers for gateway account"), is(true));
         verify(paymentDao, times(3)).persist(any(PaymentEntity.class));
     }
 

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -35,7 +35,7 @@ public class DatabaseTestHelper {
         return this;
     }
 
-    public DatabaseTestHelper addPayment(Payment payment) {
+    public DatabaseTestHelper addPayment(Payment payment, Integer gatewayAccountId) {
         jdbi.withHandle(handle -> handle.createStatement("INSERT INTO payments " +
                 "(external_id, govuk_payment_id, next_url, product_id, status, amount, gateway_account_id, reference_number)" +
                 "VALUES " +
@@ -46,7 +46,7 @@ public class DatabaseTestHelper {
                 .bind("product_id",payment.getProductId())
                 .bind("status", payment.getStatus())
                 .bind("amount", payment.getAmount())
-                .bind("gateway_account_id", payment.getGatewayAccountId())
+                .bind("gateway_account_id", gatewayAccountId)
                 .bind("reference_number", payment.getReferenceNumber())
                 .execute());
 

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -37,15 +37,17 @@ public class DatabaseTestHelper {
 
     public DatabaseTestHelper addPayment(Payment payment) {
         jdbi.withHandle(handle -> handle.createStatement("INSERT INTO payments " +
-                "(external_id, govuk_payment_id, next_url, product_id, status, amount)" +
+                "(external_id, govuk_payment_id, next_url, product_id, status, amount, gateway_account_id, reference_number)" +
                 "VALUES " +
-                "(:external_id, :govuk_payment_id, :next_url, :product_id, :status, :amount)")
+                "(:external_id, :govuk_payment_id, :next_url, :product_id, :status, :amount, :gateway_account_id, :reference_number)")
                 .bind("external_id", payment.getExternalId())
                 .bind("govuk_payment_id", payment.getGovukPaymentId())
                 .bind("next_url", payment.getNextUrl())
                 .bind("product_id",payment.getProductId())
                 .bind("status", payment.getStatus())
                 .bind("amount", payment.getAmount())
+                .bind("gateway_account_id", payment.getGatewayAccountId())
+                .bind("reference_number", payment.getReferenceNumber())
                 .execute());
 
         return this;
@@ -61,7 +63,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getPaymentsByProductExternalId(String productExternalId) {
         return jdbi.withHandle(h ->
-                h.createQuery("SELECT pa.id, pa.external_id, pa.govuk_payment_id, pa.next_url, pa.date_created, pa.product_id, pa.status, pa.amount " +
+                h.createQuery("SELECT pa.id, pa.external_id, pa.govuk_payment_id, pa.next_url, pa.date_created, pa.product_id, pa.status, pa.amount, pa.reference_number " +
                         "FROM payments pa, products pr " +
                         "WHERE pr.id = pa.product_id " +
                         "AND pr.external_id = :product_external_id")


### PR DESCRIPTION
- add/refactor payments entity to cater for DB changes (new columns)
- add unique two columns constraint to  gateway_account_id and reference_number on payments    - add logic to set random reference number at payment creation
- add error handling in case gateway_account_id and reference_number uniqueness is violated
- update/add tests