### PR TITLE
PP-2996 avoid tagging after AWS deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
       }
       steps {
         deployPaas("products", "test", null, true)
-        deploy("products", "test", null, true, false, "uk.gov.pay.endtoend.categories.SmokeProducts")
+        deploy("products", "test", null, false, false, "uk.gov.pay.endtoend.categories.SmokeProducts")
       }
     }
   }


### PR DESCRIPTION
As it is already tagged after PaaS deployment.