### PR TITLE
PP-2996 Enable smoke test and Specify PROMOTED_ENV

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
       }
       steps {
         deployPaas("products", "test", null, true)
-        deploy("products", "test", null, false, true, "uk.gov.pay.endtoend.categories.SmokeProducts")
+        deploy("products", "test", null, false, true, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
       }
       steps {
         deployPaas("products", "test", null, true)
-        deploy("products", "test", null, false, false, "uk.gov.pay.endtoend.categories.SmokeProducts")
+        deploy("products", "test", null, false, true, "uk.gov.pay.endtoend.categories.SmokeProducts")
       }
     }
   }


### PR DESCRIPTION
1. Enabling smoke test in products (AWS)
2. set PROMOTED_ENV to true. So that smoke tests will use non instance specific environment URLs. see (alphagov/pay-jenkins-library#23)