### PR TITLE
PP-3032/create adhoc products

### DIFF
--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -75,7 +75,7 @@ public class Product {
         String returnUrl = (jsonPayload.get(RETURN_URL) != null) ? jsonPayload.get(RETURN_URL).asText() : null;
         String serviceName = (jsonPayload.get(FIELD_SERVICE_NAME) != null) ? jsonPayload.get(FIELD_SERVICE_NAME).asText() : null;
 
-        return new Product(randomUuid(), name, description, paiApiToken,
+        return new Product(randomUuid(), name, description, payApiToken,
                 price, ProductStatus.ACTIVE, gatewayAccountId, serviceName, type, returnUrl);
     }
 

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.products.model;
 
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.products.util.ProductStatus;
+import uk.gov.pay.products.util.ProductType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +24,7 @@ public class Product {
     private static final String EXTERNAL_ID = "external_id";
     private static final String DESCRIPTION = "description";
     private static final String STATUS = "status";
+    private static final String TYPE = "type";
     private static final String FIELD_GATEWAY_ACCOUNT_ID = "gateway_account_id";
     private static final String RETURN_URL = "return_url";
     private static final String FIELD_SERVICE_NAME = "service_name";
@@ -34,6 +35,7 @@ public class Product {
     private String payApiToken;
     private Long price;
     private ProductStatus status;
+    private ProductType type;
     private Integer gatewayAccountId;
     private List<Link> links = new ArrayList<>();
     private String returnUrl;
@@ -48,6 +50,7 @@ public class Product {
             @JsonProperty(STATUS) ProductStatus status,
             @JsonProperty(FIELD_GATEWAY_ACCOUNT_ID) Integer gatewayAccountId,
             @JsonProperty(FIELD_SERVICE_NAME) String serviceName,
+            @JsonProperty(TYPE) ProductType type,
             @JsonProperty(RETURN_URL) String returnUrl)
     {
         this.externalId = externalId;
@@ -58,20 +61,22 @@ public class Product {
         this.status = status;
         this.gatewayAccountId = gatewayAccountId;
         this.serviceName = serviceName;
+        this.type = type;
         this.returnUrl = returnUrl;
     }
 
     public static Product from(JsonNode jsonPayload) {
-        String paiApiToken = (jsonPayload.get(FIELD_PAY_API_TOKEN) != null) ? jsonPayload.get(FIELD_PAY_API_TOKEN).asText() : null;
+        String payApiToken = (jsonPayload.get(FIELD_PAY_API_TOKEN) != null) ? jsonPayload.get(FIELD_PAY_API_TOKEN).asText() : null;
         String name = (jsonPayload.get(FIELD_NAME) != null) ? jsonPayload.get(FIELD_NAME).asText() : null;
         Long price = (jsonPayload.get(FIELD_PRICE) != null) ? jsonPayload.get(FIELD_PRICE).asLong() : null;
         Integer gatewayAccountId = (jsonPayload.get(FIELD_GATEWAY_ACCOUNT_ID) != null ? jsonPayload.get(FIELD_GATEWAY_ACCOUNT_ID).asInt() : null);
         String description = (jsonPayload.get(DESCRIPTION) != null) ? jsonPayload.get(DESCRIPTION).asText() : null;
+        ProductType type = (jsonPayload.get(TYPE) != null) ? ProductType.valueOf(jsonPayload.get(TYPE).asText()) : null;
         String returnUrl = (jsonPayload.get(RETURN_URL) != null) ? jsonPayload.get(RETURN_URL).asText() : null;
         String serviceName = (jsonPayload.get(FIELD_SERVICE_NAME) != null) ? jsonPayload.get(FIELD_SERVICE_NAME).asText() : null;
 
         return new Product(randomUuid(), name, description, paiApiToken,
-                price, ProductStatus.ACTIVE, gatewayAccountId, serviceName, returnUrl);
+                price, ProductStatus.ACTIVE, gatewayAccountId, serviceName, type, returnUrl);
     }
 
     public String getName() {
@@ -112,6 +117,10 @@ public class Product {
     @JsonProperty("_links")
     public List<Link> getLinks() {
         return links;
+    }
+
+    public ProductType getType() {
+        return type;
     }
 
     public String getReturnUrl() {

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
@@ -2,13 +2,9 @@ package uk.gov.pay.products.persistence.entity;
 
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.util.ProductStatus;
+import uk.gov.pay.products.util.ProductType;
 
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -41,6 +37,10 @@ public class ProductEntity extends AbstractEntity {
 
     @Column(name = "gateway_account_id")
     private Integer gatewayAccountId;
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    private ProductType type = ProductType.DEMO;
 
     @Column(name = "return_url")
     private String returnUrl;
@@ -95,8 +95,8 @@ public class ProductEntity extends AbstractEntity {
         return status;
     }
 
-    public void setStatus(ProductStatus status) {
-        this.status = status;
+    public void setType(ProductType type) {
+        this.type = type;
     }
 
     public ZonedDateTime getDateCreated() {
@@ -113,6 +113,22 @@ public class ProductEntity extends AbstractEntity {
 
     public void setGatewayAccountId(Integer gatewayAccountId) {
         this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public ProductType getType() {
+        return type;
+    }
+
+    public void setStatus(ProductStatus status) {
+        this.status = status;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public void setReturnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
     }
 
     public static ProductEntity from(Product product) {
@@ -141,6 +157,7 @@ public class ProductEntity extends AbstractEntity {
                 this.status,
                 this.gatewayAccountId,
                 this.serviceName,
+                this.type,
                 this.returnUrl);
     }
 

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
@@ -123,14 +123,6 @@ public class ProductEntity extends AbstractEntity {
         this.status = status;
     }
 
-    public String getReturnUrl() {
-        return returnUrl;
-    }
-
-    public void setReturnUrl(String returnUrl) {
-        this.returnUrl = returnUrl;
-    }
-
     public static ProductEntity from(Product product) {
         ProductEntity productEntity = new ProductEntity();
 
@@ -141,6 +133,7 @@ public class ProductEntity extends AbstractEntity {
         productEntity.setExternalId(product.getExternalId());
         productEntity.setDescription(product.getDescription());
         productEntity.setGatewayAccountId(product.getGatewayAccountId());
+        productEntity.setType(product.getType());
         productEntity.setReturnUrl(product.getReturnUrl());
         productEntity.setServiceName(product.getServiceName());
 

--- a/src/main/java/uk/gov/pay/products/util/ProductType.java
+++ b/src/main/java/uk/gov/pay/products/util/ProductType.java
@@ -1,0 +1,10 @@
+package uk.gov.pay.products.util;
+
+/**
+ * Type field to be used for {@link uk.gov.pay.products.persistence.entity.ProductEntity}
+ */
+public enum ProductType {
+    DEMO,
+    PROTOTYPE,
+    ADHOC
+}

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -15,8 +15,7 @@ public class ProductRequestValidator {
     private static final String FIELD_PRICE = "price";
     private static final String FIELD_RETURN_URL = "return_url";
     private static final String FIELD_SERVICE_NAME = "service_name";
-
-
+    private static final String FIELD_TYPE = "type";
 
     @Inject
     public ProductRequestValidator(RequestValidations requestValidations) {
@@ -30,6 +29,7 @@ public class ProductRequestValidator {
                 FIELD_PAY_API_TOKEN,
                 FIELD_NAME,
                 FIELD_PRICE,
+                FIELD_TYPE
                 FIELD_SERVICE_NAME);
 
         if (!errors.isPresent() && payload.get(FIELD_RETURN_URL)!= null){
@@ -38,6 +38,10 @@ public class ProductRequestValidator {
 
         if (!errors.isPresent() && payload.get(FIELD_PRICE) != null) {
             errors = requestValidations.checkIsBelowMaxAmount(payload, FIELD_PRICE);
+        }
+
+        if (!errors.isPresent() && payload.get(FIELD_TYPE) != null) {
+            errors = requestValidations.checkIsProductType(payload, FIELD_TYPE);
         }
 
         return errors.map(Errors::from);

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -29,7 +29,7 @@ public class ProductRequestValidator {
                 FIELD_PAY_API_TOKEN,
                 FIELD_NAME,
                 FIELD_PRICE,
-                FIELD_TYPE
+                FIELD_TYPE,
                 FIELD_SERVICE_NAME);
 
         if (!errors.isPresent() && payload.get(FIELD_RETURN_URL)!= null){

--- a/src/main/resources/migrations/00011_add_column_type_to_products.sql
+++ b/src/main/resources/migrations/00011_add_column_type_to_products.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_type_on_products
+ALTER TABLE products ADD COLUMN type VARCHAR(255) NOT NULL DEFAULT 'DEMO';
+
+--rollback alter table products drop column type;

--- a/src/main/resources/migrations/00014_add_column_type_to_products.sql
+++ b/src/main/resources/migrations/00014_add_column_type_to_products.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
 --changeset uk.gov.pay:add_column_type_on_products
-ALTER TABLE products ADD COLUMN type VARCHAR(255) NOT NULL DEFAULT 'DEMO';
+ALTER TABLE products ADD COLUMN type VARCHAR(255) NOT NULL DEFAULT 'PROTOTYPE';
 
 --rollback alter table products drop column type;

--- a/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
+++ b/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
@@ -2,6 +2,7 @@ package uk.gov.pay.products.fixtures;
 
 import uk.gov.pay.products.persistence.entity.ProductEntity;
 import uk.gov.pay.products.util.ProductStatus;
+import uk.gov.pay.products.util.ProductType;
 
 import java.time.ZonedDateTime;
 
@@ -16,6 +17,7 @@ public class ProductEntityFixture {
     private Long price = 100L;
     private String returnUrl = "http://return.url";
     private ProductStatus status = ProductStatus.ACTIVE;
+    private ProductType type = ProductType.DEMO;
     private String externalId = randomUuid();
     private ZonedDateTime dateCreated = ZonedDateTime.now();
     private int gatewayAccountId;
@@ -31,6 +33,7 @@ public class ProductEntityFixture {
         product.setExternalId(externalId);
         product.setPrice(price);
         product.setStatus(status);
+        product.setType(type);
         product.setGatewayAccountId(gatewayAccountId);
         product.setReturnUrl(returnUrl);
         product.setServiceName(serviceName);
@@ -64,6 +67,11 @@ public class ProductEntityFixture {
 
     public ProductEntityFixture withServiceName(String serviceName) {
         this.serviceName = serviceName;
+        return this;
+    }
+
+    public ProductEntityFixture withType(ProductType type) {
+        this.type = type;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
@@ -10,12 +10,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
+import uk.gov.pay.products.util.ProductType;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
@@ -54,6 +52,7 @@ public class ProductCreatorTest {
                 null,
                 gatewayAccountId,
                 null,
+                ProductType.DEMO,
                 null
         );
 
@@ -73,6 +72,8 @@ public class ProductCreatorTest {
         assertThat(productEntity.getDateCreated(), is(notNullValue()));
         assertThat(productEntity.getGatewayAccountId(), is(notNullValue()));
         assertThat(productEntity.getGatewayAccountId(), is(gatewayAccountId));
+        assertThat(productEntity.getType(), is(notNullValue()));
+        assertThat(productEntity.getType(), is(ProductType.DEMO));
     }
 
     @Test
@@ -89,6 +90,7 @@ public class ProductCreatorTest {
                 null,
                 gatewayAccountId,
                 SERVICE_NAME,
+                ProductType.DEMO,
                 returnUrl
         );
 

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -18,10 +18,10 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper addProduct(Product product) {
         jdbi.withHandle(handle -> handle.createStatement("INSERT INTO products " +
                 "(external_id, name, description, pay_api_token, price, " +
-                "status, return_url, gateway_account_id)" +
+                "status, return_url, type, gateway_account_id)" +
                 "VALUES " +
                 "(:external_id, :name, :description, :pay_api_token, :price, " +
-                ":status, :return_url, :gateway_account_id)")
+                ":status, :return_url, :type, :gateway_account_id)")
                 .bind("external_id", product.getExternalId())
                 .bind("name", product.getName())
                 .bind("description", product.getDescription())
@@ -29,6 +29,7 @@ public class DatabaseTestHelper {
                 .bind("price", product.getPrice())
                 .bind("status", product.getStatus())
                 .bind("return_url", product.getReturnUrl())
+                .bind("type", product.getType())
                 .bind("gateway_account_id", product.getGatewayAccountId())
                 .execute());
 

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -22,13 +22,13 @@ public class ProductRequestValidatorTest {
     private static final String FIELD_PRICE = "price";
     private static final String FIELD_SERVICE_NAME = "service_name";
     private static final String FIELD_TYPE = "type";
-    private static final String RETURN_URL = "return_url";
+    private static final String FIELD_RETURN_URL = "return_url";
     private static final String VALID_RETURN_URL = "https://valid.url";
 
     private static ProductRequestValidator productRequestValidator = new ProductRequestValidator(new RequestValidations());
 
     @Test
-    public void shouldPass_whenAllFieldsPresent(){
+    public void shouldPass_whenAllFieldsPresent() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(
                         ImmutableMap.<String, String>builder()
@@ -49,13 +49,15 @@ public class ProductRequestValidatorTest {
     @Test
     public void shouldPass_whenReturnUrlFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_NAME, "name",
-                        FIELD_SERVICE_NAME, "Example service",
-                        FIELD_PRICE, 25.00,
-                        FIELD_TYPE, ProductType.DEMO.name()));
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_PRICE, "25.00")
+                                .put(FIELD_TYPE, ProductType.DEMO.name())
+                                .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -65,13 +67,16 @@ public class ProductRequestValidatorTest {
     @Test
     public void shouldPass_whenPriceIsBelowMaxPrice() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_NAME, "name",
-                        FIELD_SERVICE_NAME, "Example service",
-                        FIELD_PRICE, MAX_PRICE - 1L,
-                        FIELD_TYPE, ProductType.DEMO.toString()));
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_PRICE, String.valueOf(MAX_PRICE - 1))
+                                .put(FIELD_TYPE, ProductType.DEMO.toString())
+                                .build());
+
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -81,13 +86,14 @@ public class ProductRequestValidatorTest {
     @Test
     public void shouldError_whenPriceFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_NAME, "name",
-                        FIELD_SERVICE_NAME, "Example service",
-                        RETURN_URL, VALID_RETURN_URL,
-                        FIELD_TYPE, ProductType.DEMO.toString()));
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                        .put(FIELD_PAY_API_TOKEN, "api_token")
+                        .put(FIELD_NAME, "name")
+                        .put(FIELD_SERVICE_NAME, "Example service")
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .put(FIELD_TYPE, ProductType.DEMO.toString())
+                        .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -138,13 +144,14 @@ public class ProductRequestValidatorTest {
     @Test
     public void shouldError_whenNameFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_PRICE, 25.00,
-                        FIELD_SERVICE_NAME, "Example service",
-                        FIELD_TYPE, ProductType.DEMO.toString(),
-                        FIELD_RETURN_URL, VALID_RETURN_URL));
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                        .put(FIELD_PAY_API_TOKEN, "api_token")
+                        .put(FIELD_PRICE, "25.00")
+                        .put(FIELD_SERVICE_NAME, "Example service")
+                        .put(FIELD_TYPE, ProductType.DEMO.toString())
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -155,13 +162,14 @@ public class ProductRequestValidatorTest {
     @Test
     public void shouldError_whenApiTokenFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_NAME, "name",
-                        FIELD_PRICE, 25.00,
-                        FIELD_SERVICE_NAME, "Example service",
-                        FIELD_TYPE, ProductType.DEMO.toString(),
-                        FIELD_RETURN_URL, VALID_RETURN_URL));
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                        .put(FIELD_NAME, "name")
+                        .put(FIELD_PRICE, "25.00")
+                        .put(FIELD_SERVICE_NAME, "Example service")
+                        .put(FIELD_TYPE, ProductType.DEMO.toString())
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -172,46 +180,32 @@ public class ProductRequestValidatorTest {
     @Test
     public void shouldError_whenGatewayAccountIdFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_NAME, "name",
-                        FIELD_SERVICE_NAME, "Example service",
-                        FIELD_PRICE, 25.00,
-                        FIELD_TYPE, ProductType.DEMO.toString(),
-                        FIELD_RETURN_URL, VALID_RETURN_URL));
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_PAY_API_TOKEN, "api_token")
+                        .put(FIELD_NAME, "name")
+                        .put(FIELD_SERVICE_NAME, "Example service")
+                        .put(FIELD_PRICE, "25.00")
+                        .put(FIELD_TYPE, ProductType.DEMO.toString())
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
         assertThat(errors.isPresent(), is(true));
         assertThat(errors.get().getErrors().toString(), is("[Field [gateway_account_id] is required]"));
     }
-    
-    @Test
-    public void shouldError_whenReturnUrlIsInvalid(){
-        JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_NAME, "name",
-                        FIELD_PRICE, 25.00,
-                        RETURN_URL, "return_url"));
-
-        Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
-
-        assertThat(errors.isPresent(), is(true));
-        assertThat(errors.get().getErrors().toString(), is("[Field [type] is required]"));
-    }
 
     @Test
     public void shouldError_whenTypeIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_GATEWAY_ACCOUNT_ID, 1,
-                        FIELD_PAY_API_TOKEN, "api_token",
-                        FIELD_NAME, "name",
-                        FIELD_PRICE, 25.00,
-                        FIELD_SERVICE_NAME, "Example service",
-                        FIELD_RETURN_URL, VALID_RETURN_URL));
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                        .put(FIELD_PAY_API_TOKEN, "api_token")
+                        .put(FIELD_NAME, "name")
+                        .put(FIELD_PRICE, "25.00")
+                        .put(FIELD_SERVICE_NAME, "Example service")
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -228,10 +222,11 @@ public class ProductRequestValidatorTest {
                                 .put(FIELD_PAY_API_TOKEN, "api_token")
                                 .put(FIELD_NAME, "name")
                                 .put(FIELD_PRICE, "25.0")
+                                .put(FIELD_SERVICE_NAME, "Example service")
                                 .put(FIELD_TYPE, "UNKNOWN")
                                 .put(FIELD_RETURN_URL, VALID_RETURN_URL)
                                 .build());
-                        
+
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
         assertThat(errors.isPresent(), is(true));
@@ -247,10 +242,11 @@ public class ProductRequestValidatorTest {
                                 .put(FIELD_PAY_API_TOKEN, "api_token")
                                 .put(FIELD_NAME, "name")
                                 .put(FIELD_PRICE, "25.0")
+                                .put(FIELD_SERVICE_NAME, "Example service")
                                 .put(FIELD_TYPE, ProductType.DEMO.toString())
                                 .put(FIELD_RETURN_URL, "return_url")
                                 .build());
-                        
+
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
 

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.pay.products.util.Errors;
+import uk.gov.pay.products.util.ProductType;
 
 import java.util.Optional;
 
@@ -20,6 +21,7 @@ public class ProductRequestValidatorTest {
     private static final String FIELD_NAME = "name";
     private static final String FIELD_PRICE = "price";
     private static final String FIELD_SERVICE_NAME = "service_name";
+    private static final String FIELD_TYPE = "type";
     private static final String RETURN_URL = "return_url";
     private static final String VALID_RETURN_URL = "https://valid.url";
 
@@ -27,18 +29,17 @@ public class ProductRequestValidatorTest {
 
     @Test
     public void shouldPass_whenAllFieldsPresent(){
-        ImmutableMap<Object, Object> map = ImmutableMap.builder()
-                .put(FIELD_GATEWAY_ACCOUNT_ID, 1)
-                .put(FIELD_PAY_API_TOKEN, "api_token")
-                .put(FIELD_NAME, "name")
-                .put(FIELD_PRICE, 25.00)
-                .put(FIELD_SERVICE_NAME, "Example service")
-                .put(RETURN_URL, VALID_RETURN_URL)
-                .build();
-
-
         JsonNode payload = new ObjectMapper()
-                .valueToTree(map);
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_PRICE, "25.00")
+                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_TYPE, ProductType.DEMO.toString())
+                                .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                                .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -46,14 +47,15 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldPass_whenReturnUrlFieldIsMissing(){
+    public void shouldPass_whenReturnUrlFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(
                         FIELD_GATEWAY_ACCOUNT_ID, 1,
                         FIELD_PAY_API_TOKEN, "api_token",
                         FIELD_NAME, "name",
                         FIELD_SERVICE_NAME, "Example service",
-                        FIELD_PRICE, 25.00));
+                        FIELD_PRICE, 25.00,
+                        FIELD_TYPE, ProductType.DEMO.name()));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -61,14 +63,15 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldPass_whenPriceIsBelowMaxPrice(){
+    public void shouldPass_whenPriceIsBelowMaxPrice() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(
                         FIELD_GATEWAY_ACCOUNT_ID, 1,
                         FIELD_PAY_API_TOKEN, "api_token",
                         FIELD_NAME, "name",
                         FIELD_SERVICE_NAME, "Example service",
-                        FIELD_PRICE, MAX_PRICE - 1L));
+                        FIELD_PRICE, MAX_PRICE - 1L,
+                        FIELD_TYPE, ProductType.DEMO.toString()));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -76,14 +79,15 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenPriceFieldIsMissing(){
+    public void shouldError_whenPriceFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(
                         FIELD_GATEWAY_ACCOUNT_ID, 1,
                         FIELD_PAY_API_TOKEN, "api_token",
                         FIELD_NAME, "name",
                         FIELD_SERVICE_NAME, "Example service",
-                        RETURN_URL, VALID_RETURN_URL));
+                        RETURN_URL, VALID_RETURN_URL,
+                        FIELD_TYPE, ProductType.DEMO.toString()));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -92,18 +96,18 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenPriceFieldEqualsMaxPrice(){
-        ImmutableMap<Object, Object> map = ImmutableMap.builder()
-                .put(FIELD_GATEWAY_ACCOUNT_ID, 1)
-                .put(FIELD_PAY_API_TOKEN, "api_token")
-                .put(FIELD_NAME, "name")
-                .put(FIELD_PRICE, MAX_PRICE)
-                .put(FIELD_SERVICE_NAME, "Example service")
-                .put(RETURN_URL, VALID_RETURN_URL)
-                .build();
-
+    public void shouldError_whenPriceFieldEqualsMaxPrice() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(map);
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_PRICE, MAX_PRICE.toString())
+                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_TYPE, ProductType.DEMO.toString())
+                                .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                                .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -112,18 +116,18 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenPriceFieldExceedsMaxPrice(){
-        ImmutableMap<Object, Object> map = ImmutableMap.builder()
-                .put(FIELD_GATEWAY_ACCOUNT_ID, 1)
-                .put(FIELD_PAY_API_TOKEN, "api_token")
-                .put(FIELD_NAME, "name")
-                .put(FIELD_PRICE, MAX_PRICE + 1)
-                .put(FIELD_SERVICE_NAME, "Example service")
-                .put(RETURN_URL, VALID_RETURN_URL)
-                .build();
-
+    public void shouldError_whenPriceFieldExceedsMaxPrice() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(map);
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_PRICE, String.valueOf(MAX_PRICE + 1))
+                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_TYPE, ProductType.DEMO.toString())
+                                .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                                .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -132,14 +136,15 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenNameFieldIsMissing(){
+    public void shouldError_whenNameFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(
                         FIELD_GATEWAY_ACCOUNT_ID, 1,
                         FIELD_PAY_API_TOKEN, "api_token",
                         FIELD_PRICE, 25.00,
                         FIELD_SERVICE_NAME, "Example service",
-                        RETURN_URL, VALID_RETURN_URL));
+                        FIELD_TYPE, ProductType.DEMO.toString(),
+                        FIELD_RETURN_URL, VALID_RETURN_URL));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -148,14 +153,15 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenApiTokenFieldIsMissing(){
+    public void shouldError_whenApiTokenFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(
                         FIELD_GATEWAY_ACCOUNT_ID, 1,
                         FIELD_NAME, "name",
                         FIELD_PRICE, 25.00,
                         FIELD_SERVICE_NAME, "Example service",
-                        RETURN_URL, VALID_RETURN_URL));
+                        FIELD_TYPE, ProductType.DEMO.toString(),
+                        FIELD_RETURN_URL, VALID_RETURN_URL));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
@@ -164,57 +170,88 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenGatewayAccountIdFieldIsMissing(){
+    public void shouldError_whenGatewayAccountIdFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(
                         FIELD_PAY_API_TOKEN, "api_token",
                         FIELD_NAME, "name",
                         FIELD_SERVICE_NAME, "Example service",
                         FIELD_PRICE, 25.00,
-                        RETURN_URL, VALID_RETURN_URL));
+                        FIELD_TYPE, ProductType.DEMO.toString(),
+                        FIELD_RETURN_URL, VALID_RETURN_URL));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
         assertThat(errors.isPresent(), is(true));
         assertThat(errors.get().getErrors().toString(), is("[Field [gateway_account_id] is required]"));
     }
-
+    
     @Test
-    public void shouldError_whenServiceNameFieldIsMissing(){
-        ImmutableMap<Object, Object> map = ImmutableMap.builder()
-                .put(FIELD_GATEWAY_ACCOUNT_ID, 1)
-                .put(FIELD_PAY_API_TOKEN, "api_token")
-                .put(FIELD_NAME, "name")
-                .put(FIELD_PRICE, 25.00)
-                .put(RETURN_URL, VALID_RETURN_URL)
-                .build();
-
-
+    public void shouldError_whenReturnUrlIsInvalid(){
         JsonNode payload = new ObjectMapper()
-                .valueToTree(map);
+                .valueToTree(ImmutableMap.of(
+                        FIELD_GATEWAY_ACCOUNT_ID, 1,
+                        FIELD_PAY_API_TOKEN, "api_token",
+                        FIELD_NAME, "name",
+                        FIELD_PRICE, 25.00,
+                        RETURN_URL, "return_url"));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
         assertThat(errors.isPresent(), is(true));
-        assertThat(errors.get().getErrors().toString(), is("[Field [service_name] is required]"));
+        assertThat(errors.get().getErrors().toString(), is("[Field [type] is required]"));
     }
 
     @Test
-    public void shouldError_whenReturnUrlIsInvalid(){
-        ImmutableMap<Object, Object> map = ImmutableMap.builder()
-                .put(FIELD_GATEWAY_ACCOUNT_ID, 1)
-                .put(FIELD_PAY_API_TOKEN, "api_token")
-                .put(FIELD_NAME, "name")
-                .put(FIELD_PRICE, MAX_PRICE + 1)
-                .put(FIELD_SERVICE_NAME, "Example service")
-                .put(RETURN_URL, "return-url")
-                .build();
-
+    public void shouldError_whenTypeIsMissing() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(map);
+                .valueToTree(ImmutableMap.of(
+                        FIELD_GATEWAY_ACCOUNT_ID, 1,
+                        FIELD_PAY_API_TOKEN, "api_token",
+                        FIELD_NAME, "name",
+                        FIELD_PRICE, 25.00,
+                        FIELD_SERVICE_NAME, "Example service",
+                        FIELD_RETURN_URL, VALID_RETURN_URL));
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [type] is required]"));
+    }
+
+    @Test
+    public void shouldError_whenTypeIsUnknown() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_PRICE, "25.0")
+                                .put(FIELD_TYPE, "UNKNOWN")
+                                .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                                .build());
+                        
+        Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [type] must be a valid product type ]"));
+    }
+
+    @Test
+    public void shouldError_whenReturnUrlIsInvalid() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_PRICE, "25.0")
+                                .put(FIELD_TYPE, ProductType.DEMO.toString())
+                                .put(FIELD_RETURN_URL, "return_url")
+                                .build());
+                        
+        Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
 
 
         assertThat(errors.isPresent(), is(true));
@@ -222,21 +259,21 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenReturnUrlIsNotHttps(){
-        ImmutableMap<Object, Object> map = ImmutableMap.builder()
-                .put(FIELD_GATEWAY_ACCOUNT_ID, 1)
-                .put(FIELD_PAY_API_TOKEN, "api_token")
-                .put(FIELD_NAME, "name")
-                .put(FIELD_PRICE, MAX_PRICE + 1)
-                .put(FIELD_SERVICE_NAME, "Example service")
-                .put(RETURN_URL, "http://return.url")
-                .build();
-
+    public void shouldError_whenReturnUrlIsNotHttps() {
         JsonNode payload = new ObjectMapper()
-                .valueToTree(map);
+                .valueToTree(
+
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                                .put(FIELD_PAY_API_TOKEN, "api_token")
+                                .put(FIELD_NAME, "name")
+                                .put(FIELD_PRICE, "25.0")
+                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_TYPE, ProductType.DEMO.toString())
+                                .put(FIELD_RETURN_URL, "http://return.url")
+                                .build());
 
         Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
-
 
 
         assertThat(errors.isPresent(), is(true));


### PR DESCRIPTION
# WHAT

This introduces a type for products. We currently only support 3 different types:
* `DEMO`
* `PROTOTYPE` 
* `ADHOC`

Existing products that were created before this will all be migrated to be of type `PROTOTYPE`.

# DETAILS
- Added the product `type` field of type `VARCHAR(255)` which backfills with default value of `PROTOTYPE`.

- Created the product `type` enum.
- Added the product `type` attribute to the product model, making it in request/response payloads of product APIs.
- Added the product `type` attribute to the product entity, making it persistent.
- Added request validation, making product type mandatory and been one of the valid types `DEMO`, `PROTOTYPE`, `ADHOC`.
- Set the type to be `PROTOTYPE` as default in the database scheme migration.