### PR TITLE
PP-3048 Keep service name in sync

### DIFF
--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -28,6 +28,7 @@ import uk.gov.pay.products.filters.LoggingFilter;
 import uk.gov.pay.products.healthchecks.DatabaseHealthCheck;
 import uk.gov.pay.products.healthchecks.DependentResourceWaitCommand;
 import uk.gov.pay.products.healthchecks.Ping;
+import uk.gov.pay.products.resources.GatewayAccountResource;
 import uk.gov.pay.products.resources.HealthCheckResource;
 import uk.gov.pay.products.resources.PaymentResource;
 import uk.gov.pay.products.resources.ProductResource;
@@ -83,6 +84,7 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(ProductResource.class));
         environment.jersey().register(injector.getInstance(PaymentResource.class));
+        environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
 
         environment.jersey().register(new AuthDynamicFeature(
                 new OAuthCredentialAuthFilter.Builder<Token>()

--- a/src/main/java/uk/gov/pay/products/config/ProductsModule.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsModule.java
@@ -9,6 +9,7 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.products.client.RestClientFactory;
 import uk.gov.pay.products.client.publicapi.PublicApiRestClient;
+import uk.gov.pay.products.service.GatewayAccountFactory;
 import uk.gov.pay.products.service.LinksDecorator;
 import uk.gov.pay.products.service.PaymentFactory;
 import uk.gov.pay.products.service.PaymentFinder;
@@ -52,6 +53,7 @@ public class ProductsModule extends AbstractModule {
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(ProductFactory.class));
         install(new FactoryModuleBuilder().build(PaymentFactory.class));
+        install(new FactoryModuleBuilder().build(GatewayAccountFactory.class));
     }
 
     private JpaPersistModule jpaModule(ProductsConfiguration configuration) {

--- a/src/main/java/uk/gov/pay/products/config/ProductsModule.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsModule.java
@@ -15,6 +15,7 @@ import uk.gov.pay.products.service.PaymentFactory;
 import uk.gov.pay.products.service.PaymentFinder;
 import uk.gov.pay.products.service.ProductFactory;
 import uk.gov.pay.products.service.ProductFinder;
+import uk.gov.pay.products.validations.GatewayAccountRequestValidator;
 import uk.gov.pay.products.validations.ProductRequestValidator;
 import uk.gov.pay.products.validations.RequestValidations;
 
@@ -41,6 +42,7 @@ public class ProductsModule extends AbstractModule {
         bind(Environment.class).toInstance(environment);
         bind(RequestValidations.class).in(Singleton.class);
         bind(ProductRequestValidator.class).in(Singleton.class);
+        bind(GatewayAccountRequestValidator.class).in(Singleton.class);
         bind(LinksDecorator.class).toInstance(
                 new LinksDecorator(
                         configuration.getBaseUrl(), configuration.getProductsUiPayUrl()));

--- a/src/main/java/uk/gov/pay/products/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/products/model/GatewayAccountRequest.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.products.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+public class GatewayAccountRequest {
+
+    public static final String FIELD_OPERATION = "op";
+    public static final String FIELD_OPERATION_PATH = "path";
+    public static final String FIELD_VALUE = "value";
+
+    private String op;
+    private String path;
+    private JsonNode value;
+
+    public String getOp() {
+        return op;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String valueAsString() {
+        if (value != null && value.isTextual()) {
+            return value.asText();
+        }
+        return null;
+    }
+
+    public List<String> valueAsList() {
+        if (value != null && value.isArray()) {
+            return newArrayList(value.elements())
+                    .stream()
+                    .map(node -> node.textValue())
+                    .collect(toList());
+        }
+        return null;
+    }
+
+    public Map<String, String> valueAsObject() {
+        if (value != null) {
+            if ((value.isTextual() && !isEmpty(value.asText())) || (!value.isNull() && value.isObject())) {
+                try {
+                    return new ObjectMapper().readValue(value.traverse(), new TypeReference<Map<String, String>>() {});
+                } catch (IOException e) {
+                    throw new RuntimeException(format("Malformed JSON object in GatewayAccountRequest.value"), e);
+                }
+            }
+        }
+        return null;
+    }
+
+
+    private GatewayAccountRequest(String op, String path, JsonNode value) {
+        this.op = op;
+        this.path = path;
+        this.value = value;
+    }
+
+    public static GatewayAccountRequest from(JsonNode payload) {
+        return new GatewayAccountRequest(
+                payload.get(FIELD_OPERATION).asText(),
+                payload.get(FIELD_OPERATION_PATH).asText(),
+                payload.get(FIELD_VALUE));
+
+    }
+}

--- a/src/main/java/uk/gov/pay/products/model/PatchRequest.java
+++ b/src/main/java/uk/gov/pay/products/model/PatchRequest.java
@@ -13,7 +13,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-public class GatewayAccountRequest {
+public class PatchRequest {
 
     public static final String FIELD_OPERATION = "op";
     public static final String FIELD_OPERATION_PATH = "path";
@@ -54,7 +54,7 @@ public class GatewayAccountRequest {
                 try {
                     return new ObjectMapper().readValue(value.traverse(), new TypeReference<Map<String, String>>() {});
                 } catch (IOException e) {
-                    throw new RuntimeException(format("Malformed JSON object in GatewayAccountRequest.value"), e);
+                    throw new RuntimeException(format("Malformed JSON object in PatchRequest.value"), e);
                 }
             }
         }
@@ -62,14 +62,14 @@ public class GatewayAccountRequest {
     }
 
 
-    private GatewayAccountRequest(String op, String path, JsonNode value) {
+    private PatchRequest(String op, String path, JsonNode value) {
         this.op = op;
         this.path = path;
         this.value = value;
     }
 
-    public static GatewayAccountRequest from(JsonNode payload) {
-        return new GatewayAccountRequest(
+    public static PatchRequest from(JsonNode payload) {
+        return new PatchRequest(
                 payload.get(FIELD_OPERATION).asText(),
                 payload.get(FIELD_OPERATION_PATH).asText(),
                 payload.get(FIELD_VALUE));

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
 import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
 
@@ -77,6 +78,12 @@ public class Product {
 
         return new Product(randomUuid(), name, description, payApiToken,
                 price, ProductStatus.ACTIVE, gatewayAccountId, serviceName, type, returnUrl);
+    }
+
+    public static Product valueOf(ProductEntity productEntity) {
+        return new Product(productEntity.getExternalId(), productEntity.getName(), productEntity.getDescription(), productEntity.getPayApiToken(),
+                productEntity.getPrice(), productEntity.getStatus(), productEntity.getGatewayAccountId(), productEntity.getServiceName(),
+                productEntity.getType(), productEntity.getReturnUrl());
     }
 
     public String getName() {

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -80,12 +80,6 @@ public class Product {
                 price, ProductStatus.ACTIVE, gatewayAccountId, serviceName, type, returnUrl);
     }
 
-    public static Product valueOf(ProductEntity productEntity) {
-        return new Product(productEntity.getExternalId(), productEntity.getName(), productEntity.getDescription(), productEntity.getPayApiToken(),
-                productEntity.getPrice(), productEntity.getStatus(), productEntity.getGatewayAccountId(), productEntity.getServiceName(),
-                productEntity.getType(), productEntity.getReturnUrl());
-    }
-
     public String getName() {
         return name;
     }

--- a/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.products.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import io.dropwizard.jersey.PATCH;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.products.model.GatewayAccountRequest;
+import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.service.GatewayAccountFactory;
+import uk.gov.pay.products.validations.GatewayAccountRequestValidator;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+@Path("/")
+public class GatewayAccountResource {
+
+    private static Logger logger = LoggerFactory.getLogger(GatewayAccountResource.class);
+
+    private static final String API_VERSION_PATH = "v1";
+    public static final String GATEWAY_ACCOUNT_RESOURCE_PATH = API_VERSION_PATH + "/api/gateway-account";
+    public static final String GATEWAY_ACCOUNT_API_PATH = GATEWAY_ACCOUNT_RESOURCE_PATH + "/{gatewayAccountId}";
+    private final GatewayAccountRequestValidator requestValidator;
+    private final GatewayAccountFactory gatewayAccountFactory;
+
+    @Inject
+    public GatewayAccountResource(GatewayAccountRequestValidator requestValidator, GatewayAccountFactory gatewayAccountFactory) {
+        this.requestValidator = requestValidator;
+        this.gatewayAccountFactory = gatewayAccountFactory;
+    }
+
+    @PATCH
+    @Path(GATEWAY_ACCOUNT_API_PATH)
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @PermitAll
+    public Response patchGatewayAccount(@PathParam("gatewayAccountId") Integer gatewayAccountId, JsonNode payload) {
+        logger.info("Patching gateway account [ {} ]", gatewayAccountId);
+        return requestValidator.validatePatchRequest(payload)
+                .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
+                .orElseGet(() -> {
+                            List<Product> products = gatewayAccountFactory.getUpdateService()
+                                    .doPatch(gatewayAccountId, GatewayAccountRequest.from(payload));
+                            if (products.isEmpty()) {
+                                return Response.status(NOT_FOUND).build();
+                            }
+                            return Response.ok().build();
+                        }
+                );
+    }
+}

--- a/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
@@ -5,8 +5,7 @@ import com.google.inject.Inject;
 import io.dropwizard.jersey.PATCH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.products.model.GatewayAccountRequest;
-import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.model.PatchRequest;
 import uk.gov.pay.products.service.GatewayAccountFactory;
 import uk.gov.pay.products.validations.GatewayAccountRequestValidator;
 
@@ -16,7 +15,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -28,8 +26,8 @@ public class GatewayAccountResource {
     private static Logger logger = LoggerFactory.getLogger(GatewayAccountResource.class);
 
     private static final String API_VERSION_PATH = "v1";
-    public static final String GATEWAY_ACCOUNT_RESOURCE_PATH = API_VERSION_PATH + "/api/gateway-account";
-    public static final String GATEWAY_ACCOUNT_API_PATH = GATEWAY_ACCOUNT_RESOURCE_PATH + "/{gatewayAccountId}";
+    public static final String GATEWAY_ACCOUNTS_PATH = API_VERSION_PATH + "/api/gateway-account";
+    public static final String GATEWAY_ACCOUNT_PATH = GATEWAY_ACCOUNTS_PATH + "/{gatewayAccountId}";
     private final GatewayAccountRequestValidator requestValidator;
     private final GatewayAccountFactory gatewayAccountFactory;
 
@@ -40,7 +38,7 @@ public class GatewayAccountResource {
     }
 
     @PATCH
-    @Path(GATEWAY_ACCOUNT_API_PATH)
+    @Path(GATEWAY_ACCOUNT_PATH)
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @PermitAll
@@ -49,12 +47,12 @@ public class GatewayAccountResource {
         return requestValidator.validatePatchRequest(payload)
                 .map(errors -> Response.status(BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
-                            List<Product> products = gatewayAccountFactory.getUpdateService()
-                                    .doPatch(gatewayAccountId, GatewayAccountRequest.from(payload));
-                            if (products.isEmpty()) {
-                                return Response.status(NOT_FOUND).build();
+                            Boolean success = gatewayAccountFactory.getUpdateService()
+                                    .doPatch(gatewayAccountId, PatchRequest.from(payload));
+                            if (success) {
+                                return Response.ok().build();
                             }
-                            return Response.ok().build();
+                            return Response.status(NOT_FOUND).build();
                         }
                 );
     }

--- a/src/main/java/uk/gov/pay/products/service/GatewayAccountFactory.java
+++ b/src/main/java/uk/gov/pay/products/service/GatewayAccountFactory.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.products.service;
+
+public interface GatewayAccountFactory {
+
+    GatewayAccountUpdater getUpdateService();
+}

--- a/src/main/java/uk/gov/pay/products/service/GatewayAccountUpdater.java
+++ b/src/main/java/uk/gov/pay/products/service/GatewayAccountUpdater.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.products.service;
 
 import com.google.inject.persist.Transactional;
-import uk.gov.pay.products.model.GatewayAccountRequest;
+import uk.gov.pay.products.model.PatchRequest;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
@@ -20,17 +20,14 @@ public class GatewayAccountUpdater {
     }
 
     @Transactional
-    public List<Product> doPatch(Integer gatewayAccountId, GatewayAccountRequest gatewayAccountRequest) {
+    public Boolean doPatch(Integer gatewayAccountId, PatchRequest patchRequest) {
         List<ProductEntity> productEntities = productDao.findByGatewayAccountId(gatewayAccountId);
         productEntities
                 .forEach(productEntity -> {
-                    productEntity.setServiceName(gatewayAccountRequest.valueAsString());
+                    productEntity.setServiceName(patchRequest.valueAsString());
                     productDao.merge(productEntity);
                 });
 
-        return productEntities
-                .stream()
-                .map(productEntity -> Product.valueOf(productEntity))
-                .collect(Collectors.toList());
+        return !productEntities.isEmpty();
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/GatewayAccountUpdater.java
+++ b/src/main/java/uk/gov/pay/products/service/GatewayAccountUpdater.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.products.service;
+
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.products.model.GatewayAccountRequest;
+import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.persistence.dao.ProductDao;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class GatewayAccountUpdater {
+
+    private final ProductDao productDao;
+
+    @Inject
+    public GatewayAccountUpdater(ProductDao productDao) {
+        this.productDao = productDao;
+    }
+
+    @Transactional
+    public List<Product> doPatch(Integer gatewayAccountId, GatewayAccountRequest gatewayAccountRequest) {
+        List<ProductEntity> productEntities = productDao.findByGatewayAccountId(gatewayAccountId);
+        productEntities
+                .forEach(productEntity -> {
+                    productEntity.setServiceName(gatewayAccountRequest.valueAsString());
+                    productDao.merge(productEntity);
+                });
+
+        return productEntities
+                .stream()
+                .map(productEntity -> Product.valueOf(productEntity))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/pay/products/service/GatewayAccountUpdater.java
+++ b/src/main/java/uk/gov/pay/products/service/GatewayAccountUpdater.java
@@ -8,7 +8,6 @@ import uk.gov.pay.products.persistence.entity.ProductEntity;
 
 import javax.inject.Inject;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class GatewayAccountUpdater {

--- a/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.products.validations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.pay.products.util.Errors;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION;
+import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION_PATH;
+import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_VALUE;
+
+public class GatewayAccountRequestValidator {
+
+    private final RequestValidations requestValidations;
+
+    @Inject
+    public GatewayAccountRequestValidator(RequestValidations requestValidations) {
+        this.requestValidations = requestValidations;
+    }
+
+    public Optional<Errors> validatePatchRequest(JsonNode payload) {
+        Optional<List<String>> errors = requestValidations.checkIfExists(
+                payload,
+                FIELD_OPERATION,
+                FIELD_OPERATION_PATH,
+                FIELD_VALUE);
+
+        return errors.map(Errors::from);
+    }
+}

--- a/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
@@ -7,9 +7,9 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
-import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION;
-import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION_PATH;
-import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_VALUE;
+import static uk.gov.pay.products.model.PatchRequest.FIELD_OPERATION;
+import static uk.gov.pay.products.model.PatchRequest.FIELD_OPERATION_PATH;
+import static uk.gov.pay.products.model.PatchRequest.FIELD_VALUE;
 
 public class GatewayAccountRequestValidator {
 

--- a/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
@@ -13,9 +13,9 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION;
-import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION_PATH;
-import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_VALUE;
+import static uk.gov.pay.products.model.PatchRequest.FIELD_OPERATION;
+import static uk.gov.pay.products.model.PatchRequest.FIELD_OPERATION_PATH;
+import static uk.gov.pay.products.model.PatchRequest.FIELD_VALUE;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 
 public class GatewayAccountResourceTest extends IntegrationTest {
@@ -42,7 +42,7 @@ public class GatewayAccountResourceTest extends IntegrationTest {
                 .put(FIELD_VALUE, VALUE)
                 .build();
 
-        ValidatableResponse response = givenAuthenticatedSetup()
+        givenAuthenticatedSetup()
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
                 .body(mapper.writeValueAsString(payload))

--- a/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
@@ -1,0 +1,133 @@
+package uk.gov.pay.products.resources;
+
+import com.google.common.collect.ImmutableMap;
+import io.restassured.response.ValidatableResponse;
+import org.junit.Test;
+import uk.gov.pay.products.fixtures.ProductEntityFixture;
+import uk.gov.pay.products.model.Product;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION;
+import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_OPERATION_PATH;
+import static uk.gov.pay.products.model.GatewayAccountRequest.FIELD_VALUE;
+import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
+
+public class GatewayAccountResourceTest extends IntegrationTest {
+
+    private static final String OP = "update";
+    private static final String PATH = "service_name";
+    private static final String VALUE = "A New Name";
+
+    @Test
+    public void shouldUpdateServiceName_withValidMandatoryFields() throws Exception {
+        Integer gatewayAccountId = randomInt();
+
+        Product product = ProductEntityFixture.aProductEntity()
+                .withGatewayAccountId(gatewayAccountId)
+                .withServiceName("Old Service Name")
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(product);
+
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put(FIELD_OPERATION, OP)
+                .put(FIELD_OPERATION_PATH, PATH)
+                .put(FIELD_VALUE, VALUE)
+                .build();
+
+        ValidatableResponse response = givenAuthenticatedSetup()
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch("/v1/api/gateway-account/" + gatewayAccountId)
+                .then()
+                .statusCode(200);
+
+        List<Map<String, Object>> productsRecords = databaseHelper.findProductEntityByGatewayAccountId(gatewayAccountId);
+
+        assertThat(productsRecords.get(0), hasEntry("service_name", VALUE));
+    }
+
+    @Test
+    public void shouldUpdateMultipleRecordsServiceName_withValidMandatoryFields() throws Exception {
+        Integer gatewayAccountId = randomInt();
+
+        Product product1 = ProductEntityFixture.aProductEntity()
+                .withGatewayAccountId(gatewayAccountId)
+                .withServiceName("Old Service Name")
+                .build()
+                .toProduct();
+
+        Product product2 = ProductEntityFixture.aProductEntity()
+                .withGatewayAccountId(gatewayAccountId)
+                .withServiceName("Old Service Name")
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(product1);
+        databaseHelper.addProduct(product2);
+
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put(FIELD_OPERATION, OP)
+                .put(FIELD_OPERATION_PATH, PATH)
+                .put(FIELD_VALUE, VALUE)
+                .build();
+
+        givenAuthenticatedSetup()
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch("/v1/api/gateway-account/" + gatewayAccountId)
+                .then()
+                .statusCode(200);
+
+        List<Map<String, Object>> productsRecords = databaseHelper.findProductEntityByGatewayAccountId(gatewayAccountId);
+
+        assertThat(productsRecords.get(0), hasEntry("service_name", VALUE));
+        assertThat(productsRecords.get(1), hasEntry("service_name", VALUE));
+    }
+
+    @Test
+    public void updateAProduct_shouldFail_whenNotAuthenticated() throws Exception {
+        givenSetup()
+                .accept(APPLICATION_JSON)
+                .patch(format("/v1/api/gateway-account/%s", randomInt()))
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void givenANonExistingProduct_whenUpdateAServiceName_shouldReturn404() throws Exception {
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put(FIELD_OPERATION, OP)
+                .put(FIELD_OPERATION_PATH, PATH)
+                .put(FIELD_VALUE, VALUE)
+                .build();
+
+        givenAuthenticatedSetup()
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/gateway-account/%s", randomInt()))
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void shouldError_whenUpdatingAServiceName_withMandatoryFieldsMissing() throws Exception {
+        givenAuthenticatedSetup()
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .body(mapper.writeValueAsString("{}"))
+                .patch(format("/v1/api/gateway-account/%s", randomInt()))
+                .then()
+                .statusCode(400);
+    }
+}

--- a/src/test/java/uk/gov/pay/products/service/GatewayAccountUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/products/service/GatewayAccountUpdaterTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.pay.products.model.GatewayAccountRequest;
+import uk.gov.pay.products.model.PatchRequest;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
@@ -15,7 +15,6 @@ import java.util.List;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,15 +34,15 @@ public class GatewayAccountUpdaterTest {
     public void shouldUpdateServiceName_whenSingleProduct() throws Exception {
         Integer gatewayAccountId = 1000;
         String serviceName = "New Service Name";
-        GatewayAccountRequest request = GatewayAccountRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "notify_settings",
                 "value", serviceName)));
 
         ProductEntity productEntity = mock(ProductEntity.class);
         when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList(productEntity));
 
-        List<Product> productList = updater.doPatch(gatewayAccountId, request);
-        assertThat(productList.size(), is(1));
+        Boolean success = updater.doPatch(gatewayAccountId, request);
+        assertThat(success, is(true));
         verify(productDao, times(1)).merge(productEntity);
         verify(productEntity, times(1)).setServiceName(serviceName);
     }
@@ -52,7 +51,7 @@ public class GatewayAccountUpdaterTest {
     public void shouldUpdateServiceName_whenTwoProduct() throws Exception {
         Integer gatewayAccountId = 1000;
         String serviceName = "New Service Name";
-        GatewayAccountRequest request = GatewayAccountRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "notify_settings",
                 "value", serviceName)));
 
@@ -60,8 +59,8 @@ public class GatewayAccountUpdaterTest {
         ProductEntity productEntity2 = mock(ProductEntity.class);
         when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList(productEntity1, productEntity2));
 
-        List<Product> productList = updater.doPatch(gatewayAccountId, request);
-        assertThat(productList.size(), is(2));
+        Boolean success = updater.doPatch(gatewayAccountId, request);
+        assertThat(success, is(true));
         verify(productDao, times(2)).merge(any(ProductEntity.class));
         verify(productEntity1, times(1)).setServiceName(serviceName);
         verify(productEntity2, times(1)).setServiceName(serviceName);
@@ -71,13 +70,13 @@ public class GatewayAccountUpdaterTest {
     public void shouldNotUpdateServiceName_whenNoProduct() throws Exception {
         Integer gatewayAccountId = 1000;
         String serviceName = "New Service Name";
-        GatewayAccountRequest request = GatewayAccountRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "notify_settings",
                 "value", serviceName)));
 
         when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList());
-        List<Product> productList = updater.doPatch(gatewayAccountId, request);
-        assertThat(productList.size(), is(0));
+        Boolean success = updater.doPatch(gatewayAccountId, request);
+        assertThat(success, is(false));
         verify(productDao, times(0)).merge(any(ProductEntity.class));
     }
 }

--- a/src/test/java/uk/gov/pay/products/service/GatewayAccountUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/products/service/GatewayAccountUpdaterTest.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.products.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.products.model.GatewayAccountRequest;
+import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.persistence.dao.ProductDao;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GatewayAccountUpdaterTest {
+
+    private ProductDao productDao = mock(ProductDao.class);
+    private GatewayAccountUpdater updater;
+
+    @Before
+    public void setUp() throws Exception {
+        updater = new GatewayAccountUpdater(productDao);
+    }
+
+    @Test
+    public void shouldUpdateServiceName_whenSingleProduct() throws Exception {
+        Integer gatewayAccountId = 1000;
+        String serviceName = "New Service Name";
+        GatewayAccountRequest request = GatewayAccountRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+                "path", "notify_settings",
+                "value", serviceName)));
+
+        ProductEntity productEntity = mock(ProductEntity.class);
+        when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList(productEntity));
+
+        List<Product> productList = updater.doPatch(gatewayAccountId, request);
+        assertThat(productList.size(), is(1));
+        verify(productDao, times(1)).merge(productEntity);
+        verify(productEntity, times(1)).setServiceName(serviceName);
+    }
+
+    @Test
+    public void shouldUpdateServiceName_whenTwoProduct() throws Exception {
+        Integer gatewayAccountId = 1000;
+        String serviceName = "New Service Name";
+        GatewayAccountRequest request = GatewayAccountRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+                "path", "notify_settings",
+                "value", serviceName)));
+
+        ProductEntity productEntity1 = mock(ProductEntity.class);
+        ProductEntity productEntity2 = mock(ProductEntity.class);
+        when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList(productEntity1, productEntity2));
+
+        List<Product> productList = updater.doPatch(gatewayAccountId, request);
+        assertThat(productList.size(), is(2));
+        verify(productDao, times(2)).merge(any(ProductEntity.class));
+        verify(productEntity1, times(1)).setServiceName(serviceName);
+        verify(productEntity2, times(1)).setServiceName(serviceName);
+    }
+
+    @Test
+    public void shouldNotUpdateServiceName_whenNoProduct() throws Exception {
+        Integer gatewayAccountId = 1000;
+        String serviceName = "New Service Name";
+        GatewayAccountRequest request = GatewayAccountRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+                "path", "notify_settings",
+                "value", serviceName)));
+
+        when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList());
+        List<Product> productList = updater.doPatch(gatewayAccountId, request);
+        assertThat(productList.size(), is(0));
+        verify(productDao, times(0)).merge(any(ProductEntity.class));
+    }
+}

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -3,6 +3,7 @@ package uk.gov.pay.products.utils;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.pay.products.model.Payment;
 import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
 
 import java.util.List;
 import java.util.Map;
@@ -72,4 +73,11 @@ public class DatabaseTestHelper {
                         .list());
     }
 
+    public List<Map<String, Object>> findProductEntityByGatewayAccountId(Integer gatewayAccountId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT * FROM products " +
+                    "WHERE gateway_account_id = :gateway_account_id")
+                .bind("gateway_account_id", gatewayAccountId)
+                .list());
+    }
 }

--- a/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.products.validations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.pay.products.util.Errors;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class GatewayAccountRequestValidatorTest {
+
+    private static final String FIELD_OP = "op";
+    private static final String FIELD_PATH = "path";
+    private static final String FIELD_VALUE = "value";
+
+    private GatewayAccountRequestValidator requestValidator = new GatewayAccountRequestValidator(new RequestValidations());
+
+    @Test
+    public void shouldPass_whenAllFieldsPresent() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_OP, "update")
+                                .put(FIELD_PATH, "service_name")
+                                .put(FIELD_VALUE, "A New Name")
+                                .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldError_whenValueFieldIsMissing() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_OP, "update")
+                        .put(FIELD_PATH, "service_name")
+                        .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [value] is required]"));
+    }
+
+    @Test
+    public void shouldError_whenOperationFieldIsMissing() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_PATH, "service_name")
+                        .put(FIELD_VALUE, "A New Name")
+                        .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [op] is required]"));
+    }
+
+    @Test
+    public void shouldError_whenPathFieldIsMissing() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_OP, "update")
+                        .put(FIELD_VALUE, "service_name")
+                        .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [path] is required]"));
+    }
+}

--- a/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
@@ -24,7 +24,7 @@ public class GatewayAccountRequestValidatorTest {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(
                         ImmutableMap.<String, String>builder()
-                                .put(FIELD_OP, "update")
+                                .put(FIELD_OP, "replace")
                                 .put(FIELD_PATH, "service_name")
                                 .put(FIELD_VALUE, "A New Name")
                                 .build());
@@ -38,7 +38,7 @@ public class GatewayAccountRequestValidatorTest {
     public void shouldError_whenValueFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.<String, String>builder()
-                        .put(FIELD_OP, "update")
+                        .put(FIELD_OP, "replace")
                         .put(FIELD_PATH, "service_name")
                         .build());
 
@@ -66,7 +66,7 @@ public class GatewayAccountRequestValidatorTest {
     public void shouldError_whenPathFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.<String, String>builder()
-                        .put(FIELD_OP, "update")
+                        .put(FIELD_OP, "replace")
                         .put(FIELD_VALUE, "service_name")
                         .build());
 


### PR DESCRIPTION
Implement GatewayAccountResource to update Service Name in `products`

- add validator [ece1427](https://github.com/alphagov/pay-products/commit/ece1427847646fecc58a208bae5d80287fac53de)
- add GatewayAccountUpdater and GatewayAccountRequest, refactor Product to create Product from ProductEntity [5b4f6dc](https://github.com/alphagov/pay-products/commit/5b4f6dc48a8ae8305bfcbd0dd9ba7defc78bc95a)
- add GatewayAccountFactory and configure ProductsApplication to inject GatewayAccountFactory [e5b061b](https://github.com/alphagov/pay-products/commit/e5b061b89c15aed10179c48477b59f19a54dc77d)
- add GatewayAccountResource and configuration to Application and Module [ecd5ea3](https://github.com/alphagov/pay-products/commit/ecd5ea34f36a57964d594db18b5540b639792ab9)
- add/refactor relevant tests
- address PR comments [47dc1d8](https://github.com/alphagov/pay-products/pull/57/commits/47dc1d8c1fc66f7fde1eeeec77046b40d01fda55)