### PR TITLE
PP-3048 Keep service name in sync part 2

### DIFF
--- a/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.pay.products.util.Errors;
 
 import javax.inject.Inject;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static uk.gov.pay.products.model.PatchRequest.FIELD_OPERATION;
 import static uk.gov.pay.products.model.PatchRequest.FIELD_OPERATION_PATH;
 import static uk.gov.pay.products.model.PatchRequest.FIELD_VALUE;
@@ -14,6 +18,11 @@ import static uk.gov.pay.products.model.PatchRequest.FIELD_VALUE;
 public class GatewayAccountRequestValidator {
 
     private final RequestValidations requestValidations;
+
+    private static final Map<String, List<String>> VALID_ATTRIBUTE_UPDATE_OPERATIONS = new HashMap<String, List<String>>() {{
+        put(FIELD_OPERATION, asList("replace"));
+    }};
+    public static final String FIELD_SERVICE_NAME = "service_name";
 
     @Inject
     public GatewayAccountRequestValidator(RequestValidations requestValidations) {
@@ -26,7 +35,27 @@ public class GatewayAccountRequestValidator {
                 FIELD_OPERATION,
                 FIELD_OPERATION_PATH,
                 FIELD_VALUE);
+        if(errors.isPresent()) {
+            return errors.map(Errors::from);
+        }
 
-        return errors.map(Errors::from);
+        return validateServiceNameRequest(payload).map(Errors::from);
+    }
+
+    private Optional<List<String>> validateServiceNameRequest(JsonNode payload){
+        if(!payload.findValue(FIELD_OPERATION_PATH).asText().equals(FIELD_SERVICE_NAME)) {
+            return  Optional.of(asList(format("Operation [%s] not supported for path [%s]",
+                    FIELD_OPERATION,
+                    payload.findValue(FIELD_OPERATION_PATH).asText())));
+        }
+        String op = payload.get(FIELD_OPERATION).asText();
+        if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(FIELD_OPERATION).contains(op)) {
+            return Optional.of(asList(format("Operation [%s] is not valid for path [%s]", op, FIELD_OPERATION)));
+        }
+        JsonNode valueNode = payload.get(FIELD_VALUE);
+        if(null == valueNode) {
+            return Optional.of(asList(format("Field [%s] is required", FIELD_VALUE)));
+        }
+        return requestValidations.checkIfEmpty(valueNode, FIELD_OPERATION, FIELD_OPERATION_PATH, FIELD_VALUE);
     }
 }

--- a/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/GatewayAccountRequestValidator.java
@@ -30,7 +30,7 @@ public class GatewayAccountRequestValidator {
     }
 
     public Optional<Errors> validatePatchRequest(JsonNode payload) {
-        Optional<List<String>> errors = requestValidations.checkIfExists(
+        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(
                 payload,
                 FIELD_OPERATION,
                 FIELD_OPERATION_PATH,
@@ -44,18 +44,14 @@ public class GatewayAccountRequestValidator {
 
     private Optional<List<String>> validateServiceNameRequest(JsonNode payload){
         if(!payload.findValue(FIELD_OPERATION_PATH).asText().equals(FIELD_SERVICE_NAME)) {
-            return  Optional.of(asList(format("Operation [%s] not supported for path [%s]",
-                    FIELD_OPERATION,
+            return  Optional.of(asList(format("Path %s not supported / invalid",
                     payload.findValue(FIELD_OPERATION_PATH).asText())));
         }
         String op = payload.get(FIELD_OPERATION).asText();
         if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(FIELD_OPERATION).contains(op)) {
             return Optional.of(asList(format("Operation [%s] is not valid for path [%s]", op, FIELD_OPERATION)));
         }
-        JsonNode valueNode = payload.get(FIELD_VALUE);
-        if(null == valueNode) {
-            return Optional.of(asList(format("Field [%s] is required", FIELD_VALUE)));
-        }
-        return requestValidations.checkIfEmpty(valueNode, FIELD_OPERATION, FIELD_OPERATION_PATH, FIELD_VALUE);
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -23,7 +23,7 @@ public class ProductRequestValidator {
     }
 
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
-        Optional<List<String>> errors = requestValidations.checkIfExists(
+        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(
                 payload,
                 FIELD_GATEWAY_ACCOUNT_ID,
                 FIELD_PAY_API_TOKEN,

--- a/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
@@ -5,11 +5,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import uk.gov.pay.products.util.ProductType;
 
-import javax.json.Json;
-import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.rmi.UnexpectedException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -45,6 +42,10 @@ public class RequestValidations {
 
     public Optional<List<String>> checkIsProductType(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotProductType(), fieldNames, "Field [%s] must be a valid product type ");
+    }
+
+    public Optional<List<String>> checkIfEmpty(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, notEmpty(), fieldNames, "Field [%s] is required");
     }
 
     private Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
@@ -124,4 +125,10 @@ public class RequestValidations {
         return jsonNode -> !ImmutableList.of("true", "false").contains(jsonNode.asText().toLowerCase());
     }
 
+    public static Function<JsonNode, Boolean> notEmpty() {
+            return jsonElement -> (
+                    jsonElement != null &&
+                            !isBlank(jsonElement.asText())
+            );
+    }
 }

--- a/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
@@ -28,8 +28,8 @@ public class RequestValidations {
         return applyCheck(payload, isNotUrl(), fieldNames, "Field [%s] must be a https url");
     }
 
-    public Optional<List<String>> checkIfExists(JsonNode payload, String... fieldNames) {
-        return applyCheck(payload, notExist(), fieldNames, "Field [%s] is required");
+    public Optional<List<String>> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, notExistAndNotEmpty(), fieldNames, "Field [%s] is required");
     }
 
     public Optional<List<String>> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
@@ -42,10 +42,6 @@ public class RequestValidations {
 
     public Optional<List<String>> checkIsProductType(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotProductType(), fieldNames, "Field [%s] must be a valid product type ");
-    }
-
-    public Optional<List<String>> checkIfEmpty(JsonNode payload, String... fieldNames) {
-        return applyCheck(payload, notEmpty(), fieldNames, "Field [%s] is required");
     }
 
     private Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
@@ -62,7 +58,7 @@ public class RequestValidations {
         return errors.size() > 0 ? Optional.of(errors) : Optional.empty();
     }
 
-    public Function<JsonNode, Boolean> notExist() {
+    public Function<JsonNode, Boolean> notExistAndNotEmpty() {
         return (jsonElement) -> {
             if (jsonElement instanceof ArrayNode) {
                 return notExistOrEmptyArray().apply(jsonElement);
@@ -123,12 +119,5 @@ public class RequestValidations {
 
     public static Function<JsonNode, Boolean> isNotBoolean() {
         return jsonNode -> !ImmutableList.of("true", "false").contains(jsonNode.asText().toLowerCase());
-    }
-
-    public static Function<JsonNode, Boolean> notEmpty() {
-            return jsonElement -> (
-                    jsonElement != null &&
-                            !isBlank(jsonElement.asText())
-            );
     }
 }

--- a/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.products.resources;
 
 import com.google.common.collect.ImmutableMap;
-import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.products.fixtures.ProductEntityFixture;
 import uk.gov.pay.products.model.Product;
@@ -20,7 +19,7 @@ import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 
 public class GatewayAccountResourceTest extends IntegrationTest {
 
-    private static final String OP = "update";
+    private static final String OP = "replace";
     private static final String PATH = "service_name";
     private static final String VALUE = "A New Name";
 
@@ -126,6 +125,40 @@ public class GatewayAccountResourceTest extends IntegrationTest {
                 .contentType(APPLICATION_JSON)
                 .accept(APPLICATION_JSON)
                 .body(mapper.writeValueAsString("{}"))
+                .patch(format("/v1/api/gateway-account/%s", randomInt()))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void shouldError_whenInvalidOperation() throws Exception {
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put(FIELD_OPERATION, "remove")
+                .put(FIELD_OPERATION_PATH, PATH)
+                .put(FIELD_VALUE, VALUE)
+                .build();
+
+        givenAuthenticatedSetup()
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .body(mapper.writeValueAsString(payload))
+                .patch(format("/v1/api/gateway-account/%s", randomInt()))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void shouldError_whenInvalidPath() throws Exception {
+        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
+                .put(FIELD_OPERATION, OP)
+                .put(FIELD_OPERATION_PATH, "gateway_id")
+                .put(FIELD_VALUE, VALUE)
+                .build();
+
+        givenAuthenticatedSetup()
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .body(mapper.writeValueAsString(payload))
                 .patch(format("/v1/api/gateway-account/%s", randomInt()))
                 .then()
                 .statusCode(400);

--- a/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
@@ -129,38 +129,4 @@ public class GatewayAccountResourceTest extends IntegrationTest {
                 .then()
                 .statusCode(400);
     }
-
-    @Test
-    public void shouldError_whenInvalidOperation() throws Exception {
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put(FIELD_OPERATION, "remove")
-                .put(FIELD_OPERATION_PATH, PATH)
-                .put(FIELD_VALUE, VALUE)
-                .build();
-
-        givenAuthenticatedSetup()
-                .contentType(APPLICATION_JSON)
-                .accept(APPLICATION_JSON)
-                .body(mapper.writeValueAsString(payload))
-                .patch(format("/v1/api/gateway-account/%s", randomInt()))
-                .then()
-                .statusCode(400);
-    }
-
-    @Test
-    public void shouldError_whenInvalidPath() throws Exception {
-        ImmutableMap<Object, Object> payload = ImmutableMap.builder()
-                .put(FIELD_OPERATION, OP)
-                .put(FIELD_OPERATION_PATH, "gateway_id")
-                .put(FIELD_VALUE, VALUE)
-                .build();
-
-        givenAuthenticatedSetup()
-                .contentType(APPLICATION_JSON)
-                .accept(APPLICATION_JSON)
-                .body(mapper.writeValueAsString(payload))
-                .patch(format("/v1/api/gateway-account/%s", randomInt()))
-                .then()
-                .statusCode(400);
-    }
 }

--- a/src/test/java/uk/gov/pay/products/service/GatewayAccountUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/products/service/GatewayAccountUpdaterTest.java
@@ -35,7 +35,7 @@ public class GatewayAccountUpdaterTest {
         Integer gatewayAccountId = 1000;
         String serviceName = "New Service Name";
         PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
-                "path", "notify_settings",
+                "path", "service_name",
                 "value", serviceName)));
 
         ProductEntity productEntity = mock(ProductEntity.class);
@@ -52,7 +52,7 @@ public class GatewayAccountUpdaterTest {
         Integer gatewayAccountId = 1000;
         String serviceName = "New Service Name";
         PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
-                "path", "notify_settings",
+                "path", "service_name",
                 "value", serviceName)));
 
         ProductEntity productEntity1 = mock(ProductEntity.class);
@@ -71,7 +71,7 @@ public class GatewayAccountUpdaterTest {
         Integer gatewayAccountId = 1000;
         String serviceName = "New Service Name";
         PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
-                "path", "notify_settings",
+                "path", "service_name",
                 "value", serviceName)));
 
         when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(Arrays.asList());

--- a/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
@@ -75,4 +75,20 @@ public class GatewayAccountRequestValidatorTest {
         assertThat(errors.isPresent(), is(true));
         assertThat(errors.get().getErrors().toString(), is("[Field [path] is required]"));
     }
+
+    @Test
+    public void shouldError_whenEmptyFields() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_OP, "replace")
+                                .put(FIELD_PATH, "")
+                                .put(FIELD_VALUE, "")
+                                .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [path] is required, Field [value] is required]"));
+    }
 }

--- a/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/GatewayAccountRequestValidatorTest.java
@@ -35,6 +35,21 @@ public class GatewayAccountRequestValidatorTest {
     }
 
     @Test
+    public void shouldError_whenPathIsInvalid() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_OP, "replace")
+                        .put(FIELD_PATH, "gateway_id")
+                        .put(FIELD_VALUE, "A New Name")
+                        .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Path gateway_id not supported / invalid]"));
+    }
+
+    @Test
     public void shouldError_whenValueFieldIsMissing() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.<String, String>builder()
@@ -90,5 +105,21 @@ public class GatewayAccountRequestValidatorTest {
 
         assertThat(errors.isPresent(), is(true));
         assertThat(errors.get().getErrors().toString(), is("[Field [path] is required, Field [value] is required]"));
+    }
+
+    @Test
+    public void shouldError_whenInvalidOperation() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put(FIELD_OP, "update")
+                                .put(FIELD_PATH, "gateway_id")
+                                .put(FIELD_VALUE, "A New Name")
+                                .build());
+
+        Optional<Errors> errors = requestValidator.validatePatchRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Path gateway_id not supported / invalid]"));
     }
 }


### PR DESCRIPTION
- Add path and operation validations to GatewayRequestValidator [f4ac5a4](https://github.com/alphagov/pay-products/commit/f4ac5a480804a0e69cf8214ef7e83f2ffb6bc5bd)
- Refactor GatewayAccountUpdater to use a generic BiConsumer to update DB [a10df78](https://github.com/alphagov/pay-products/commit/a10df787a9120ae6bbaac26b3bdd9e49f438795f)
- Add/refactor/fix tests