### PR TITLE
PP-3034 payment price override

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -327,7 +327,7 @@ Content-Type: application/json
 
 | Field                    | required | Description                                                      | Supported Values     |
 | ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
-| `price`                  |          | Price override for the payment amount. If not present this will defaults to product in price.| |
+| `price`                  |          | Price override for the payment amount. If not present this will defaults to price of product.| |
 
 
 #### Response field description 

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -293,6 +293,10 @@ This endpoint creates a new payment for a given product in pay-products.
 ```
 POST /v1/api/products/uier837y735n837475y3847534/payments
 Authorization: Bearer API_TOKEN
+Content-Type: application/json
+{
+    "price" : 9090,
+}
 ```
 
 ### Response example
@@ -304,7 +308,7 @@ Content-Type: application/json
         "external_id": "h6347634cwb67wii7b6ciueroytw",
         "product_external_id": "uier837y735n837475y3847534",
         "status": "CREATED",
-        "amount" : 1050,
+        "amount" : 9090,
         "_links": [
             {
                 "rel": "self",
@@ -319,6 +323,13 @@ Content-Type: application/json
         ]
     }
 ```
+#### Request body description
+
+| Field                    | required | Description                                                      | Supported Values     |
+| ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
+| `price`                  |          | Price override for the payment amount. If not present this will defaults to product in price.| |
+
+
 #### Response field description 
 | Field                    | always present | Description                                   |
 | ------------------------ |:--------------:| --------------------------------------------- |

--- a/src/main/java/uk/gov/pay/products/validations/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/PaymentRequestValidator.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.products.validations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.pay.products.util.Errors;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class PaymentRequestValidator {
+
+    public static final String FIELD_PRICE = "price";
+
+    private final RequestValidations requestValidations;
+
+    @Inject
+    public PaymentRequestValidator(RequestValidations requestValidations) {
+        this.requestValidations = requestValidations;
+    }
+
+    public Optional<Errors> validatePriceOverrideRequest(JsonNode payload) {
+        if (payload == null || payload.isNull() || newArrayList(payload.fieldNames()).isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<List<String>> errors = requestValidations.checkIfExists(payload, FIELD_PRICE);
+        if (errors.isPresent()) {
+            return Optional.of(Errors.from(errors.get()));
+        }
+        errors = requestValidations.checkIsNumeric(payload, FIELD_PRICE);
+        if (errors.isPresent()) {
+            return Optional.of(Errors.from(errors.get()));
+        }
+        errors = requestValidations.checkIsBelowMaxAmount(payload, FIELD_PRICE);
+        if (errors.isPresent()) {
+            return Optional.of(Errors.from(errors.get()));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/uk/gov/pay/products/validations/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/PaymentRequestValidator.java
@@ -24,7 +24,7 @@ public class PaymentRequestValidator {
         if (payload == null || payload.isNull() || newArrayList(payload.fieldNames()).isEmpty()) {
             return Optional.empty();
         }
-        Optional<List<String>> errors = requestValidations.checkIfExists(payload, FIELD_PRICE);
+        Optional<List<String>> errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_PRICE);
         if (errors.isPresent()) {
             return Optional.of(Errors.from(errors.get()));
         }

--- a/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
@@ -1,0 +1,71 @@
+package uk.gov.pay.products.validations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.products.util.Errors;
+
+import java.util.Optional;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class PaymentRequestValidatorTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private PaymentRequestValidator requestValidator;
+
+    @Before
+    public void before() throws Exception {
+        requestValidator = new PaymentRequestValidator(new RequestValidations());
+    }
+
+    @Test
+    public void shouldSuccess_onCreatePayment_ifJsonPayloadIsNull() throws Exception {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(null);
+        assertFalse(errors.isPresent());
+    }
+
+    @Test
+    public void shouldSuccess_onCreatePayment_ifJsonPayloadIsEmpty() throws Exception {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.readTree("{}"));
+        assertFalse(errors.isPresent());
+    }
+
+    @Test
+    public void shouldSuccess_onCreatePayment_ifJsonPayloadHasValidPrice() throws Exception {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "1900")));
+        assertFalse(errors.isPresent());
+    }
+
+    @Test
+    public void shouldError_onCreatePayment_ifJsonPayloadHasInvalidField() throws Exception {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("blah", "1900")));
+        assertTrue(errors.isPresent());
+
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors(), hasItem("Field [price] is required"));
+    }
+
+    @Test
+    public void shouldError_onCreatePayment_ifJsonPayloadHasNonNumeric() throws Exception {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "blah")));
+        assertTrue(errors.isPresent());
+
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors(), hasItem("Field [price] must be a number"));
+    }
+
+    @Test
+    public void shouldError_onCreatePayment_ifJsonPayloadBiggerThanMaxAmount() throws Exception {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "100000001")));
+        assertTrue(errors.isPresent());
+
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors(), hasItem("Field [price] must be a number below 10000000"));
+    }
+}


### PR DESCRIPTION
As part of adhoc payment journey, the paying user is able to provide the payment amount. This requires using that captured amount used during payment/charge creation which actually overrides the products price. 
There is not special CAP at the moment and the user is able to provide the maximum amount that payment platform can take at the moment.