### PR TITLE
PP-3048 Change 404 to 202 of GatewayAccount endpoint return code

### DIFF
--- a/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
@@ -17,8 +17,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
 @Path("/")
 public class GatewayAccountResource {
@@ -52,7 +52,7 @@ public class GatewayAccountResource {
                             if (success) {
                                 return Response.ok().build();
                             }
-                            return Response.status(NOT_FOUND).build();
+                            return Response.status(ACCEPTED).build();
                         }
                 );
     }

--- a/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/GatewayAccountResourceTest.java
@@ -116,7 +116,7 @@ public class GatewayAccountResourceTest extends IntegrationTest {
                 .body(mapper.writeValueAsString(payload))
                 .patch(format("/v1/api/gateway-account/%s", randomInt()))
                 .then()
-                .statusCode(404);
+                .statusCode(202);
     }
 
     @Test


### PR DESCRIPTION
- change return code. Products does not own GAs and thus it does not need to tell the caller that a specific gateway is not exists on it.