### PR TITLE
PP-3186: Reenable wait on dependencies

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-#java -jar *-allinone.jar waitOnDependencies *.yaml && \
+java -jar *-allinone.jar waitOnDependencies *.yaml && \
 java -jar *-allinone.jar db migrate *.yaml && \
 java $JAVA_OPTS -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
This not existing was causing problems in endtoend, where the app was coming up before the database and then
failing to start.