### PR TITLE
PP-3204 remove paas deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        deployPaas("products", "test", null, true)
-        deploy("products", "test", null, false, true, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
+        deploy("products", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
       }
     }
   }


### PR DESCRIPTION
We are no longer in PaaS so removing this step.
Also made deploy job to tag after deployment.