### PR TITLE
PP-3295 Service Name validation consistent across microservices

### DIFF
--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public class ProductRequestValidator {
-    private final RequestValidations requestValidations;
     private static final String FIELD_GATEWAY_ACCOUNT_ID = "gateway_account_id";
     private static final String FIELD_PAY_API_TOKEN = "pay_api_token";
     private static final String FIELD_NAME = "name";
@@ -16,6 +15,9 @@ public class ProductRequestValidator {
     private static final String FIELD_RETURN_URL = "return_url";
     private static final String FIELD_SERVICE_NAME = "service_name";
     private static final String FIELD_TYPE = "type";
+    private static final int FIELD_SERVICE_NAME_MAX_LENGTH = 50;
+
+    private final RequestValidations requestValidations;
 
     @Inject
     public ProductRequestValidator(RequestValidations requestValidations) {
@@ -32,7 +34,7 @@ public class ProductRequestValidator {
                 FIELD_TYPE,
                 FIELD_SERVICE_NAME);
 
-        if (!errors.isPresent() && payload.get(FIELD_RETURN_URL)!= null){
+        if (!errors.isPresent() && payload.get(FIELD_RETURN_URL) != null) {
             errors = requestValidations.checkIsUrl(payload, FIELD_RETURN_URL);
         }
 
@@ -42,6 +44,10 @@ public class ProductRequestValidator {
 
         if (!errors.isPresent() && payload.get(FIELD_TYPE) != null) {
             errors = requestValidations.checkIsProductType(payload, FIELD_TYPE);
+        }
+
+        if (!errors.isPresent() && payload.get(FIELD_SERVICE_NAME) != null) {
+            errors = requestValidations.checkMaxLength(payload, FIELD_SERVICE_NAME_MAX_LENGTH, FIELD_SERVICE_NAME);
         }
 
         return errors.map(Errors::from);

--- a/src/main/resources/migrations/00018_alter_column_service_name_length_products.sql
+++ b/src/main/resources/migrations/00018_alter_column_service_name_length_products.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_column_service_name_length_on_products
+ALTER TABLE products ALTER COLUMN service_name TYPE VARCHAR(50);
+
+--rollback ALTER TABLE products ALTER COLUMN service_name TYPE VARCHAR(255);

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.products.util.ProductType;
 
 import java.util.Optional;
 
+import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.products.validations.RequestValidations.MAX_PRICE;
@@ -264,7 +265,7 @@ public class ProductRequestValidatorTest {
                                 .put(FIELD_PAY_API_TOKEN, "api_token")
                                 .put(FIELD_NAME, "name")
                                 .put(FIELD_PRICE, "25.0")
-                                .put(FIELD_SERVICE_NAME, "Example service")
+                                .put(FIELD_SERVICE_NAME, randomAlphanumeric(50))
                                 .put(FIELD_TYPE, ProductType.DEMO.toString())
                                 .put(FIELD_RETURN_URL, "http://return.url")
                                 .build());
@@ -274,5 +275,25 @@ public class ProductRequestValidatorTest {
 
         assertThat(errors.isPresent(), is(true));
         assertThat(errors.get().getErrors().toString(), is("[Field [return_url] must be a https url]"));
+    }
+
+    @Test
+    public void shouldError_whenServiceNameFieldLengthIsGreaterThan50() {
+
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                        .put(FIELD_PAY_API_TOKEN, "api_token")
+                        .put(FIELD_NAME, "name")
+                        .put(FIELD_PRICE, "25.0")
+                        .put(FIELD_SERVICE_NAME, randomAlphanumeric(51))
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .put(FIELD_TYPE, ProductType.DEMO.toString())
+                        .build());
+
+        Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [service_name] must have a maximum length of 50 characters]"));
     }
 }


### PR DESCRIPTION
## WHAT
- Service names validated to be 50 characters length across all the microservices, at least until Service Names comes from a single source we need to make this work for consistency.