### PR TITLE
PP-3259 make price optional adhoc Products

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -29,7 +29,7 @@ Content-Type: application/json
 | `gateway_account_id`     |    X     | gateway account id of the Gateway Account as identified by adminusers.  |   |
 | `pay_api_token`          |    X     | valid api token for the gateway account of above service which this product takes payments for |  |
 | `name`                   |    X     | Name of the product. This will be passed as the `name` when creating the charge | |
-| `price`                  |    X     | Price for the product in pence. This will be passed as the  `amount` when creating charge    | |
+| `price`                  |          | Price for the product in pence. This will be passed as the  `amount` when creating charge. Mandatory for Non-ADHOC products    | |
 | `description`            |          | Description of the product. This will be passed as the `description` when creating the charge | |
 | `service_name`           |    X     | The name of the service associated that the product is to be associated with    |   |
 | `return_url`             |          | (https only) where to redirect to upon completion of a payment. If not provided, `pay-products` will generate a default url to itself when creating a charge | |

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -7,6 +7,8 @@ import uk.gov.pay.products.util.Errors;
 import java.util.List;
 import java.util.Optional;
 
+import static uk.gov.pay.products.util.ProductType.ADHOC;
+
 public class ProductRequestValidator {
     private static final String FIELD_GATEWAY_ACCOUNT_ID = "gateway_account_id";
     private static final String FIELD_PAY_API_TOKEN = "pay_api_token";
@@ -30,7 +32,6 @@ public class ProductRequestValidator {
                 FIELD_GATEWAY_ACCOUNT_ID,
                 FIELD_PAY_API_TOKEN,
                 FIELD_NAME,
-                FIELD_PRICE,
                 FIELD_TYPE,
                 FIELD_SERVICE_NAME);
 
@@ -44,6 +45,10 @@ public class ProductRequestValidator {
 
         if (!errors.isPresent() && payload.get(FIELD_TYPE) != null) {
             errors = requestValidations.checkIsProductType(payload, FIELD_TYPE);
+        }
+
+        if (!errors.isPresent() && !ADHOC.name().equals(payload.get(FIELD_TYPE).asText())) {
+            errors = requestValidations.checkIfExistsOrEmpty(payload, FIELD_PRICE);
         }
 
         if (!errors.isPresent() && payload.get(FIELD_SERVICE_NAME) != null) {

--- a/src/main/resources/migrations/00019_alter_column_price_null_products.sql
+++ b/src/main/resources/migrations/00019_alter_column_price_null_products.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_column_service_name_length_on_products
+ALTER TABLE products ALTER COLUMN price DROP NOT NULL;
+
+--rollback ALTER TABLE products ALTER COLUMN price SET NOT NULL;

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -85,7 +85,7 @@ public class ProductRequestValidatorTest {
     }
 
     @Test
-    public void shouldError_whenPriceFieldIsMissing() {
+    public void shouldError_whenPriceFieldIsMissing_forNonAdhocProduct() {
         JsonNode payload = new ObjectMapper()
                 .valueToTree(ImmutableMap.<String, String>builder()
                         .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
@@ -102,6 +102,23 @@ public class ProductRequestValidatorTest {
         assertThat(errors.get().getErrors().toString(), is("[Field [price] is required]"));
     }
 
+    @Test
+    public void shouldNotError_whenPriceFieldIsMissing_forAdhocProduct() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.<String, String>builder()
+                        .put(FIELD_GATEWAY_ACCOUNT_ID, "1")
+                        .put(FIELD_PAY_API_TOKEN, "api_token")
+                        .put(FIELD_NAME, "name")
+                        .put(FIELD_SERVICE_NAME, "Example service")
+                        .put(FIELD_RETURN_URL, VALID_RETURN_URL)
+                        .put(FIELD_TYPE, ProductType.ADHOC.toString())
+                        .build());
+
+        Optional<Errors> errors = productRequestValidator.validateCreateRequest(payload);
+
+        assertThat(errors.isPresent(), is(false));
+    }
+    
     @Test
     public void shouldError_whenPriceFieldExceedsMaxPrice() {
         JsonNode payload = new ObjectMapper()


### PR DESCRIPTION
For adhoc products with non fixed amount(where user enters an amount) it does not make sense to capture the price field. We can use this price field being available to support the adhoc fixed price journey