### PR TITLE
PP3253: Add run-with-chamber.sh to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
+ADD run-with-chamber.sh /app/run-with-chamber.sh
 ADD src/main/resources/ssl/*.* /etc/ssl/certs/
 
 CMD bash ./docker-startup.sh

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+set -eu
+RUN_MIGRATION=${RUN_MIGRATION:-true} # TODO this should be 'false' once e2e is up to date
+RUN_APP=${RUN_APP:-true}
+
 java -jar *-allinone.jar waitOnDependencies *.yaml && \
-java -jar *-allinone.jar db migrate *.yaml && \
-java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+
+if [ "$RUN_MIGRATION" == "true" ]; then
+  java -jar *-allinone.jar db migrate *.yaml
+fi
+
+if [ "$RUN_APP" == "true" ]; then
+  java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+fi

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh


### PR DESCRIPTION
When running in ECS we need to use chamber to fetch the secrets

When running in ECS we need to not run the migrations on the app server
so we need to configure whether to run the migrations.

I'm going to change e2e to use the correct variables but until that is
updated RUN_MIGRATIONS should default to true

solo @tlwr