### PR TITLE
PP-3253 ECSify Products in Test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("products", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
+        deploy("products", "test", null, false, false, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
+        deployEcs("products", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
       }
     }
   }


### PR DESCRIPTION
Products needs to be deployed to ECS too now. Disable tests on non ECS
deployments, and run only on ECS deployments.

Cannot be merged before commits in pay-chef for groovy changes and
pay-jenkins-library for deployEcs extra params changes

solo @belindac