### PR TITLE
PP-3441 Insecure direct object reference vulnerability

### DIFF
--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -127,4 +127,21 @@ public class Product {
     public String getReturnUrl() {
         return returnUrl;
     }
+
+    @Override
+    public String toString() {
+        return "Product{" +
+                "externalId='" + externalId + '\'' +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", payApiToken='" + payApiToken + '\'' +
+                ", price=" + price +
+                ", status=" + status +
+                ", type=" + type +
+                ", gatewayAccountId=" + gatewayAccountId +
+                ", links=" + links +
+                ", returnUrl='" + returnUrl + '\'' +
+                ", serviceName='" + serviceName + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -134,7 +134,6 @@ public class Product {
                 "externalId='" + externalId + '\'' +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
-                ", payApiToken='" + payApiToken + '\'' +
                 ", price=" + price +
                 ", status=" + status +
                 ", type=" + type +

--- a/src/main/java/uk/gov/pay/products/persistence/dao/ProductDao.java
+++ b/src/main/java/uk/gov/pay/products/persistence/dao/ProductDao.java
@@ -27,6 +27,19 @@ public class ProductDao extends JpaDao<ProductEntity> {
                 .getResultList().stream().findFirst();
     }
 
+
+    public Optional<ProductEntity> findByGatewayAccountIdAndExternalId(Integer gatewayAccountId, String externalId) {
+        String query = "SELECT product FROM ProductEntity product " +
+                "WHERE product.externalId = :externalId " +
+                "AND product.gatewayAccountId = :gatewayAccountId";
+
+        return entityManager.get()
+                .createQuery(query, ProductEntity.class)
+                .setParameter("externalId", externalId)
+                .setParameter("gatewayAccountId", gatewayAccountId)
+                .getResultList().stream().findFirst();
+    }
+
     public List<ProductEntity> findByGatewayAccountId(Integer gatewayAccountId) {
         String query = "SELECT product FROM ProductEntity product " +
                 "WHERE product.gatewayAccountId = :gatewayAccountId " +

--- a/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/GatewayAccountResource.java
@@ -19,14 +19,11 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
-@Path("/")
+@Path("/v1/api")
 public class GatewayAccountResource {
 
     private static Logger logger = LoggerFactory.getLogger(GatewayAccountResource.class);
 
-    private static final String API_VERSION_PATH = "v1";
-    public static final String GATEWAY_ACCOUNTS_PATH = API_VERSION_PATH + "/api/gateway-account";
-    public static final String GATEWAY_ACCOUNT_PATH = GATEWAY_ACCOUNTS_PATH + "/{gatewayAccountId}";
     private final GatewayAccountRequestValidator requestValidator;
     private final GatewayAccountFactory gatewayAccountFactory;
 
@@ -37,7 +34,7 @@ public class GatewayAccountResource {
     }
 
     @PATCH
-    @Path(GATEWAY_ACCOUNT_PATH)
+    @Path("/gateway-account/{gatewayAccountId}")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     public Response patchGatewayAccount(@PathParam("gatewayAccountId") Integer gatewayAccountId, JsonNode payload) {

--- a/src/main/java/uk/gov/pay/products/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/PaymentResource.java
@@ -14,17 +14,11 @@ import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
-import static uk.gov.pay.products.resources.ProductResource.PRODUCT_RESOURCE_PATH;
 
-@Path("/")
+@Path("/v1/api")
 public class PaymentResource {
 
     private static Logger logger = LoggerFactory.getLogger(PaymentResource.class);
-
-    private static final String API_VERSION_PATH = "v1";
-    public static final String PAYMENTS_RESOURCE_PATH = API_VERSION_PATH + "/api/payments";
-    public static final String PAYMENT_RESOURCE_PATH = PAYMENTS_RESOURCE_PATH + "/{paymentExternalId}";
-    public static final String PRODUCT_PAYMENTS_RESOURCE_PATH = PRODUCT_RESOURCE_PATH + "/payments";
 
     private final PaymentFactory paymentFactory;
     private final PaymentRequestValidator requestValidator;
@@ -35,7 +29,7 @@ public class PaymentResource {
         this.requestValidator = requestValidator;
     }
 
-    @Path(PAYMENT_RESOURCE_PATH)
+    @Path("/payments/{paymentExternalId}")
     @GET
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
@@ -48,7 +42,7 @@ public class PaymentResource {
                         Response.status(NOT_FOUND).build());
     }
 
-    @Path(PRODUCT_PAYMENTS_RESOURCE_PATH)
+    @Path("/products/{productExternalId}/payments")
     @POST
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
@@ -70,7 +64,7 @@ public class PaymentResource {
         }
     }
 
-    @Path(PRODUCT_PAYMENTS_RESOURCE_PATH)
+    @Path("/products/{productExternalId}/payments")
     @GET
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -47,6 +47,7 @@ public class ProductResource {
 
     // TODO: TO BE REMOVED!
     // Leaving this provisionally for backward compatibility
+    @Deprecated
     @GET
     @Path("/products/{productExternalId}")
     @Produces(APPLICATION_JSON)
@@ -75,6 +76,7 @@ public class ProductResource {
 
     // TODO: TO BE REMOVED!
     // Leaving this provisionally for backward compatibility
+    @Deprecated
     @PATCH
     @Path("/products/{productExternalId}/disable")
     @Produces(APPLICATION_JSON)
@@ -99,6 +101,7 @@ public class ProductResource {
 
     // TODO: TO BE REMOVED!
     // Leaving this provisionally for backward compatibility
+    @Deprecated
     @GET
     @Path("/products")
     @Produces(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -45,11 +45,13 @@ public class ProductResource {
 
     }
 
+    // TODO: TO BE REMOVED!
+    // Leaving this provisionally for backward compatibility
     @GET
     @Path("/products/{productExternalId}")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response findProduct(@PathParam("productExternalId") String productExternalId) {
+    public Response deprecatedFindProduct(@PathParam("productExternalId") String productExternalId) {
         logger.info("Find a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().findByExternalId(productExternalId)
                 .map(product ->
@@ -58,21 +60,58 @@ public class ProductResource {
                         Response.status(NOT_FOUND).build());
     }
 
+    @GET
+    @Path("/gateway-account/{gatewayAccountId}/products/{productExternalId}")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response findProduct(@PathParam("gatewayAccountId") Integer gatewayAccountId, @PathParam("productExternalId") String productExternalId) {
+        logger.info("Find a product with externalId - [ {} ]", productExternalId);
+        return productFactory.productFinder().findByGatewayAccountIdAndExternalId(gatewayAccountId, productExternalId)
+                .map(product ->
+                        Response.status(OK).entity(product).build())
+                .orElseGet(() ->
+                        Response.status(NOT_FOUND).build());
+    }
+
+    // TODO: TO BE REMOVED!
+    // Leaving this provisionally for backward compatibility
     @PATCH
     @Path("/products/{productExternalId}/disable")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response disableProduct(@PathParam("productExternalId") String productExternalId) {
+    public Response deprecatedDisableProduct(@PathParam("productExternalId") String productExternalId) {
         logger.info("Disabling a product with externalId - [ {} ]", productExternalId);
-        return productFactory.productFinder().disableProduct(productExternalId)
+        return productFactory.productFinder().disableByExternalId(productExternalId)
                 .map(product -> Response.status(NO_CONTENT).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
+    @PATCH
+    @Path("/gateway-account/{gatewayAccountId}/products/{productExternalId}/disable")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response disableProduct(@PathParam("gatewayAccountId") Integer gatewayAccountId, @PathParam("productExternalId") String productExternalId) {
+        logger.info("Disabling a product with externalId - [ {} ]", productExternalId);
+        return productFactory.productFinder().disableByGatewayAccountIdAndExternalId(gatewayAccountId, productExternalId)
+                .map(product -> Response.status(NO_CONTENT).build())
+                .orElseGet(() -> Response.status(NOT_FOUND).build());
+    }
+
+    // TODO: TO BE REMOVED!
+    // Leaving this provisionally for backward compatibility
     @GET
     @Path("/products")
     @Produces(APPLICATION_JSON)
-    public Response findProducts(@QueryParam("gatewayAccountId") Integer gatewayAccountId) {
+    public Response deprecatedFindProducts(@QueryParam("gatewayAccountId") Integer gatewayAccountId) {
+        logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);
+        List<Product> products = productFactory.productFinder().findByGatewayAccountId(gatewayAccountId);
+        return Response.status(OK).entity(products).build();
+    }
+
+    @GET
+    @Path("/gateway-account/{gatewayAccountId}/products")
+    @Produces(APPLICATION_JSON)
+    public Response findProducts(@PathParam("gatewayAccountId") Integer gatewayAccountId) {
         logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);
         List<Product> products = productFactory.productFinder().findByGatewayAccountId(gatewayAccountId);
         return Response.status(OK).entity(products).build();

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -17,18 +17,12 @@ import java.util.List;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
 
-@Path("/")
+@Path("/v1/api")
 public class ProductResource {
     private static Logger logger = LoggerFactory.getLogger(ProductResource.class);
 
-    private static final String API_VERSION_PATH = "v1";
-    public static final String PRODUCTS_RESOURCE_PATH = API_VERSION_PATH + "/api/products";
-    public static final String PRODUCT_RESOURCE_PATH = PRODUCTS_RESOURCE_PATH + "/{productExternalId}";
-    public static final String DISABLE_PRODUCT_RESOURCE_PATH = PRODUCTS_RESOURCE_PATH + "/{productExternalId}/disable";
-
     private final ProductRequestValidator requestValidator;
     private final ProductFactory productFactory;
-
 
     @Inject
     public ProductResource(ProductRequestValidator requestValidator, ProductFactory productFactory) {
@@ -37,7 +31,7 @@ public class ProductResource {
     }
 
     @POST
-    @Path(PRODUCTS_RESOURCE_PATH)
+    @Path("/products")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response createProduct(JsonNode payload) {
@@ -52,7 +46,7 @@ public class ProductResource {
     }
 
     @GET
-    @Path(PRODUCT_RESOURCE_PATH)
+    @Path("/products/{productExternalId}")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response findProduct(@PathParam("productExternalId") String productExternalId) {
@@ -65,7 +59,7 @@ public class ProductResource {
     }
 
     @PATCH
-    @Path(DISABLE_PRODUCT_RESOURCE_PATH)
+    @Path("/products/{productExternalId}/disable")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response disableProduct(@PathParam("productExternalId") String productExternalId) {
@@ -76,7 +70,7 @@ public class ProductResource {
     }
 
     @GET
-    @Path(PRODUCTS_RESOURCE_PATH)
+    @Path("/products")
     @Produces(APPLICATION_JSON)
     public Response findProducts(@QueryParam("gatewayAccountId") Integer gatewayAccountId) {
         logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);

--- a/src/main/java/uk/gov/pay/products/service/LinksDecorator.java
+++ b/src/main/java/uk/gov/pay/products/service/LinksDecorator.java
@@ -9,8 +9,6 @@ import java.net.URI;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.UriBuilder.fromUri;
-import static uk.gov.pay.products.resources.PaymentResource.PAYMENTS_RESOURCE_PATH;
-import static uk.gov.pay.products.resources.ProductResource.PRODUCTS_RESOURCE_PATH;
 
 public class LinksDecorator {
 
@@ -23,7 +21,7 @@ public class LinksDecorator {
     }
 
     public Product decorate(Product product) {
-        Link selfLink = makeSelfLink(GET, PRODUCTS_RESOURCE_PATH, product.getExternalId());
+        Link selfLink = makeSelfLink(GET, "v1/api/products", product.getExternalId());
         product.getLinks().add(selfLink);
 
         Link payLink = makeProductsUIUri(POST, product.getExternalId());
@@ -33,7 +31,7 @@ public class LinksDecorator {
     }
 
     public Payment decorate(Payment payment){
-        Link selfLink = makeSelfLink(GET, PAYMENTS_RESOURCE_PATH, payment.getExternalId());
+        Link selfLink = makeSelfLink(GET, "v1/api/payments", payment.getExternalId());
         payment.getLinks().add(selfLink);
 
         Link nextUrl = makeNextUrlLink(GET, payment.getNextUrl());

--- a/src/main/java/uk/gov/pay/products/service/ProductFinder.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductFinder.java
@@ -28,6 +28,12 @@ public class ProductFinder {
     }
 
     @Transactional
+    public Optional<Product> findByGatewayAccountIdAndExternalId(Integer gatewayAccountId, String externalId) {
+        return productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)
+                .map(productEntity -> linksDecorator.decorate(productEntity.toProduct()));
+    }
+
+    @Transactional
     public Optional<Product> disableProduct(String externalId) {
         return productDao.findByExternalId(externalId)
                 .map(productEntity -> {

--- a/src/main/java/uk/gov/pay/products/service/ProductFinder.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductFinder.java
@@ -34,8 +34,18 @@ public class ProductFinder {
     }
 
     @Transactional
-    public Optional<Product> disableProduct(String externalId) {
+    public Optional<Product> disableByExternalId(String externalId) {
         return productDao.findByExternalId(externalId)
+                .map(productEntity -> {
+                    productEntity.setStatus(ProductStatus.INACTIVE);
+                    return Optional.of(productEntity.toProduct());
+                })
+                .orElseGet(Optional::empty);
+    }
+
+    @Transactional
+    public Optional<Product> disableByGatewayAccountIdAndExternalId(Integer gatewayAccountId, String externalId) {
+        return productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)
                 .map(productEntity -> {
                     productEntity.setStatus(ProductStatus.INACTIVE);
                     return Optional.of(productEntity.toProduct());

--- a/src/test/java/uk/gov/pay/products/matchers/ProductMatcher.java
+++ b/src/test/java/uk/gov/pay/products/matchers/ProductMatcher.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.products.matchers;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import uk.gov.pay.products.model.Product;
+
+public class ProductMatcher {
+    public static Matcher<Product> isSame(final Product expectedProduct) {
+        return new BaseMatcher<Product>() {
+            @Override
+            public boolean matches(final Object obj) {
+                final Product actualProduct = (Product) obj;
+
+                return ((actualProduct != null) &&
+                        (expectedProduct != null) &&
+                        StringUtils.equals(actualProduct.getExternalId(), expectedProduct.getExternalId()) &&
+                        StringUtils.equals(actualProduct.getPayApiToken(), expectedProduct.getPayApiToken()) &&
+                        StringUtils.equals(actualProduct.getDescription(), expectedProduct.getDescription()) &&
+                        StringUtils.equals(actualProduct.getName(), expectedProduct.getName()) &&
+                        NumberUtils.compare(actualProduct.getPrice(), expectedProduct.getPrice()) == 0 &&
+                        actualProduct.getStatus() == expectedProduct.getStatus() &&
+                        actualProduct.getType() == expectedProduct.getType() &&
+                        NumberUtils.compare(actualProduct.getGatewayAccountId(), expectedProduct.getGatewayAccountId()) == 0 &&
+                        StringUtils.equals(actualProduct.getReturnUrl(), expectedProduct.getReturnUrl()) &&
+                        StringUtils.equals(actualProduct.getServiceName(), expectedProduct.getServiceName()));
+            }
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("Product ").appendValue(expectedProduct);
+            }
+        };
+    }
+}
+

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
@@ -9,7 +9,6 @@ import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
 
 import javax.ws.rs.HttpMethod;
-import java.io.Serializable;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
@@ -150,7 +150,7 @@ public class ProductResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void givenAnExistingExternalProductId_shouldFindAndReturnProduct() throws Exception {
+    public void findProduct_shouldReturnProduct_whenFound() throws Exception {
         String externalId = randomUuid();
         int gatewayAccountId = randomInt();
 
@@ -165,7 +165,7 @@ public class ProductResourceTest extends IntegrationTest {
         ValidatableResponse response = givenSetup()
                 .when()
                 .accept(APPLICATION_JSON)
-                .get(format("/v1/api/products/%s", externalId))
+                .get(format("/v1/api/gateway-account/%s/products/%s", gatewayAccountId, externalId))
                 .then()
                 .statusCode(200);
 
@@ -193,16 +193,16 @@ public class ProductResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void givenANonExistingExternalProductId_shouldReturn404() throws Exception {
+    public void findProduct_shouldReturn404_whenNotFound() throws Exception {
         givenSetup()
                 .accept(APPLICATION_JSON)
-                .get(format("/v1/api/products/%s", randomUuid()))
+                .get(format("/v1/api/gateway-account/%s/products/%s", randomInt(), randomUuid()))
                 .then()
                 .statusCode(404);
     }
 
     @Test
-    public void givenAValidExternalProductId_shouldDisableTheProduct() throws Exception {
+    public void disableProduct_shouldReturn201_whenProductIsDisabled() throws Exception {
         String externalId = randomUuid();
         int gatewayAccountId = randomInt();
 
@@ -224,7 +224,7 @@ public class ProductResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void givenANonExistingExternalProductId_whenDisableAProduct_shouldReturn404() throws Exception {
+    public void disableProduct_shouldReturn404_whenNotFound() throws Exception {
         givenSetup()
                 .when()
                 .accept(APPLICATION_JSON)
@@ -234,7 +234,7 @@ public class ProductResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void givenAnExistingGatewayAccountId_shouldFindAndReturnProducts() throws Exception {
+    public void findProducts_shouldReturnActiveProducts_whenFound() throws Exception {
         int gatewayAccountId = randomInt();
 
         Product product = ProductEntityFixture.aProductEntity()
@@ -254,7 +254,7 @@ public class ProductResourceTest extends IntegrationTest {
         ValidatableResponse response = givenSetup()
                 .when()
                 .accept(APPLICATION_JSON)
-                .get(format("/v1/api/products?gatewayAccountId=%s", gatewayAccountId))
+                .get(format("/v1/api/gateway-account/%s/products", gatewayAccountId))
                 .then()
                 .statusCode(200);
 
@@ -268,19 +268,19 @@ public class ProductResourceTest extends IntegrationTest {
     }
 
     @Test
-    public void givenNonExistingGatewayAccountId_shouldNoProduct() throws Exception {
+    public void findProducts_shouldReturnNoProduct_whenNoneFound() throws Exception {
         int unknownGatewayAccountId = randomInt();
         givenSetup()
                 .when()
                 .accept(APPLICATION_JSON)
-                .get(format("/v1/api/products?gatewayAccountId=%s", unknownGatewayAccountId))
+                .get(format("/v1/api/gateway-account/%s/products", unknownGatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("", hasSize(0));
     }
 
     @Test
-    public void givenAnExistingGatewayAccountId_whenProductIsAlreadyDisabled_thenShouldNoProduct() throws Exception {
+    public void findProducts_shouldNotReturnInactiveProducts() throws Exception {
         int gatewayAccountId = randomInt();
 
         Product product = ProductEntityFixture.aProductEntity()
@@ -294,7 +294,7 @@ public class ProductResourceTest extends IntegrationTest {
         givenSetup()
                 .when()
                 .accept(APPLICATION_JSON)
-                .get(format("/v1/api/products?gatewayAccountId=%s", gatewayAccountId))
+                .get(format("/v1/api/gateway-account/%s/products", gatewayAccountId))
                 .then()
                 .statusCode(200)
                 .body("", hasSize(0));

--- a/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -32,7 +34,7 @@ public class ProductFinderTest {
     }
 
     @Test
-    public void shouldReturnProduct_whenFoundByExternalId() throws Exception{
+    public void findByExternalId_shouldReturnProduct_whenFound() throws Exception{
         String externalId = "1";
         ProductEntity productEntity = new ProductEntity();
         productEntity.setExternalId(externalId);
@@ -40,22 +42,49 @@ public class ProductFinderTest {
 
         Optional<Product> productOptional = productFinder.findByExternalId(externalId);
 
-        assertThat(productOptional.isPresent(), is(true));
+        assertTrue(productOptional.isPresent());
         assertThat(productOptional.get().getExternalId(), is(externalId));
     }
 
     @Test
-    public void shouldReturnEmpty_whenNoProductFound() throws Exception {
+    public void findByExternalId_shouldReturnEmpty_whenNotFound() throws Exception {
         String externalId = "1";
         when(productDao.findByExternalId(externalId)).thenReturn(Optional.empty());
 
         Optional<Product> productOptional = productFinder.findByExternalId(externalId);
 
-        assertThat(productOptional.isPresent(), is(false));
+        assertFalse(productOptional.isPresent());
     }
 
     @Test
-    public void givenAnExistingProduct_shouldDisableIt() throws Exception{
+    public void findByGatewayAccountIdAndExternalId_shouldReturnProduct_whenFound() throws Exception{
+        Integer gatewayAccountId = 1;
+        String externalId = "1";
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setExternalId(externalId);
+        productEntity.setGatewayAccountId(gatewayAccountId);
+        when(productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)).thenReturn(Optional.of(productEntity));
+
+        Optional<Product> productOptional = productFinder.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId);
+
+        assertTrue(productOptional.isPresent());
+        assertThat(productOptional.get().getExternalId(), is(externalId));
+    }
+
+    @Test
+    public void findByGatewayAccountIdAndExternalId_shouldReturnEmpty_whenNotFound() throws Exception {
+        Integer gatewayAccountId = 1;
+        Integer anotherGatewayAccountId = 2;
+        String externalId = "1";
+        when(productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)).thenReturn(Optional.empty());
+
+        Optional<Product> productOptional = productFinder.findByGatewayAccountIdAndExternalId(anotherGatewayAccountId, externalId);
+
+        assertFalse(productOptional.isPresent());
+    }
+
+    @Test
+    public void disableProduct_shouldDisableProduct() throws Exception{
         String externalId = "1";
         ProductEntity productEntity = new ProductEntity();
         productEntity.setExternalId(externalId);

--- a/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
@@ -74,17 +74,16 @@ public class ProductFinderTest {
     @Test
     public void findByGatewayAccountIdAndExternalId_shouldReturnEmpty_whenNotFound() throws Exception {
         Integer gatewayAccountId = 1;
-        Integer anotherGatewayAccountId = 2;
         String externalId = "1";
         when(productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)).thenReturn(Optional.empty());
 
-        Optional<Product> productOptional = productFinder.findByGatewayAccountIdAndExternalId(anotherGatewayAccountId, externalId);
+        Optional<Product> productOptional = productFinder.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId);
 
         assertFalse(productOptional.isPresent());
     }
 
     @Test
-    public void disableProduct_shouldDisableProduct() throws Exception{
+    public void disableByExternalId_shouldDisableProduct_whenFound() throws Exception{
         String externalId = "1";
         ProductEntity productEntity = new ProductEntity();
         productEntity.setExternalId(externalId);
@@ -94,10 +93,51 @@ public class ProductFinderTest {
         assertThat(productOptional.isPresent(), is(true));
         assertThat(productOptional.get().getStatus(), is(ProductStatus.ACTIVE));
 
-        productFinder.disableProduct(externalId);
-        productOptional = productFinder.findByExternalId(externalId);
+        Optional<Product> disabledProduct = productFinder.disableByExternalId(externalId);
 
+        assertThat(disabledProduct.isPresent(), is(true));
+        assertThat(disabledProduct.get().getStatus(), is(ProductStatus.INACTIVE));
+    }
+
+    @Test
+    public void disableByExternalId_shouldReturnEmpty_whenNotFound() throws Exception{
+        String externalId = "1";
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setExternalId(externalId);
+        when(productDao.findByExternalId(externalId)).thenReturn(Optional.empty());
+
+        Optional<Product> disabledProduct = productFinder.disableByExternalId(externalId);
+
+        assertFalse(disabledProduct.isPresent());
+    }
+
+    @Test
+    public void disableByGatewayAccountIdAndExternalId_shouldDisableProduct_whenFound() throws Exception{
+        Integer gatewayAccountId = 1;
+        String externalId = "1";
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setExternalId(externalId);
+        productEntity.setGatewayAccountId(gatewayAccountId);
+        when(productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)).thenReturn(Optional.of(productEntity));
+
+        Optional<Product> productOptional = productFinder.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId);
         assertThat(productOptional.isPresent(), is(true));
-        assertThat(productOptional.get().getStatus(), is(ProductStatus.INACTIVE));
+        assertThat(productOptional.get().getStatus(), is(ProductStatus.ACTIVE));
+
+        Optional<Product> disabledProduct = productFinder.disableByGatewayAccountIdAndExternalId(gatewayAccountId, externalId);
+
+        assertThat(disabledProduct.isPresent(), is(true));
+        assertThat(disabledProduct.get().getStatus(), is(ProductStatus.INACTIVE));
+    }
+
+    @Test
+    public void disableByGatewayAccountIdAndExternalId_shouldReturnEmpty_whenNotFound() throws Exception{
+        Integer gatewayAccountId = 1;
+        String externalId = "1";
+        when(productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)).thenReturn(Optional.empty());
+
+        Optional<Product> disabledProduct = productFinder.disableByGatewayAccountIdAndExternalId(gatewayAccountId, externalId);
+
+        assertFalse(disabledProduct.isPresent());
     }
 }

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -19,10 +19,10 @@ public class DatabaseTestHelper {
     public DatabaseTestHelper addProduct(Product product) {
         jdbi.withHandle(handle -> handle.createStatement("INSERT INTO products " +
                 "(external_id, name, description, pay_api_token, price, " +
-                "status, return_url, type, gateway_account_id)" +
+                "status, return_url, type, gateway_account_id, service_name)" +
                 "VALUES " +
                 "(:external_id, :name, :description, :pay_api_token, :price, " +
-                ":status, :return_url, :type, :gateway_account_id)")
+                ":status, :return_url, :type, :gateway_account_id, :service_name)")
                 .bind("external_id", product.getExternalId())
                 .bind("name", product.getName())
                 .bind("description", product.getDescription())
@@ -32,6 +32,7 @@ public class DatabaseTestHelper {
                 .bind("return_url", product.getReturnUrl())
                 .bind("type", product.getType())
                 .bind("gateway_account_id", product.getGatewayAccountId())
+                .bind("service_name", product.getServiceName())
                 .execute());
 
         return this;


### PR DESCRIPTION
While creating new ` Prototype Links ` and ` Payment Links `in selfservice we were vulnerable to insecure direct object references as we failed to verify that products belong to gateway accounts for certain operations. To mitigate this problem, product API has been updated to explicitly force to provide the gateway account id in the path for all operations. 

* Substituted all variables in resource paths by their value to make it more
readable what the actual path for a resource is. This is consistent with the 
approach taken in other `Dropwizard` project such as Connector. 

* Added a method called `findByGatewayAccountIdAndExternalId` in `ProductDao` that restraints the lookup of products by their respective accounts. As part of this, a few missing tests have also been retrofitted. 

* Added a method called `findByGatewayAccountIdAndExternalId` in `ProductFinder` that restraints the lookup of products by their respective accounts.

* Added new endpoints mimicking the exact same functional behaviour of  existing endpoints to find/disable products but constraint by gateway accounts. Prevented insecure object reference for the following operations:
	* Find a product by external id *and gateway account id*, `/gateway-account/{gatewayAccountId}/products/{productExternalId}`
	* Disable a product by external id *and gateway account id*`/gateway-account/{gatewayAccountId}/products/{productExternalId}/disable`
	* Find all active products by *gateway account id*`/gateway-account/{gatewayAccountId}/products`
Note: The old endpoint have been kept provisionally for backward compatibility. A subsequent PR will remove them after final merge. 