### PR TITLE
PP-3441 Reinstated endpoints previously deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ The JSON naming convention follows Hypertext Application Language (HAL).
 | Path                          | Supported Methods | Description                        |
 | ----------------------------- | ----------------- | ---------------------------------- |
 |[```/v1/api/products```](docs/api_specification.md#post-v1apiproducts)        | POST    |  Creates a new product definition            |
-|[```/v1/api/products/{productId}```](docs/api_specification.md#get-v1apiproductsproductid)        | GET    |  Gets an existing product with the specified Id   |
-|[```/v1/api/products?gatewayAccountId={gatewayAccountId}```](docs/api_specification.md#get-v1apiproductsgatewayaccountid)        | GET    |  Gets lists of products that belongs to a gateway account   |
-|[```/v1/api/products/{productId}```](docs/api_specification.md#delete-v1apiproductsproductid)        | DELETE    |  Deletes/Disables the product with the specified Id   |
+|[```/v1/api/products/{productId}```](docs/api_specification.md#get-v1apiproductsproductid)        | GET    |  Gets an existing product with the specified productId   |
+|[```/v1/api/gateway-account/{gatewayAccountId}/products/{productId}```](docs/api_specification.md#get-v1apigateway\-accountgatewayaccountidproductsproductid)        | GET    |  Gets an existing product with the specified productId that belong to the gateway account specified by gatewayAccountId. Returns the product only if it exists in the given gateway account. Useful to avoid insecure direct object reference. |
+|[```/v1/api/gateway-account/{gatewayAccountId}/products```](docs/api_specification.md#get-v1apigateway\-accountgatewayaccountidproducts)        | GET    |  Gets lists of products that belongs to a gateway account specified by gatewayAccountId  |
+|[```/v1/api/products/{productId}```](docs/api_specification.md#delete-v1apiproductsproductid)        | DELETE    |  Deletes/Disables the product with the specified productId   |
+|[```/v1/api/gateway-account/{gatewayAccountId}/products/{productId}```](docs/api_specification.md#delete-v1apigateway\-accountgatewayaccountidproductsproductexternaliddisable)        | DELETE    |  Deletes/Disables the product with the specified productId that belong to the gateway account specified by gatewayAccountId. Deletes/Disables the product only if it exists in the given gateway account. Useful to avoid insecure direct object reference. |
 |[```/v1/api/payments```](docs/api_specification.md#post-v1apipayments)        | POST    | Creates a new payment                        |
 |[```/v1/api/payments/{paymentId}```](docs/api_specification.md#get-v1apipaymentspaymentid) |  GET  |     Gets an existing payment    |
-|[```/v1/api/products/{productId}/payments```](docs/api_specification.md#get-v1apiproductsproductidpayments) | GET | Gets a list of payments that belong to a specific product  |
-|[```/v1/api/gateway-account/{gatewayAccountId}```](docs/api_specification.md#get-v1apigatewayaccountgatewayaccountid) | PATCH | Updates a specific field of a given gateway-account of products |  
+|[```/v1/api/products/{productId}/payments```](docs/api_specification.md#get-v1apiproductsproductidpayments) | GET | Gets a list of payments that belong to a specific product specified by productId |
+|[```/v1/api/gateway-account/{gatewayAccountId}```](docs/api_specification.md#get-v1apigatewayaccountgatewayaccountid) | PATCH | Updates a specific field of a given gateway-account of products specified by gatewayAccountId |  

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -77,7 +77,7 @@ Content-Type: application/json
 
 ## GET /v1/api/products/{productId}
 
-This endpoint finds a product with the specified external product id
+This endpoint finds a product with the specified productId
 
 ```
 GET /v1/api/products/874h5c87834659q345698495
@@ -110,13 +110,50 @@ Content-Type: application/json
 #### Response field description 
 same as above(docs/api_specification.md#post-v1apiproducts)
 
+## GET /v1/api/gateway-account/{gatewayAccountId}/products/{productId}
 
-## GET /v1/api/products?gatewayAccountId={gatewayAccountId}
+This endpoint finds a product with the specified productId that belongs to the gateway account specified by gatewayAccountId
 
-This endpoint retrieves list of products that belongs to the specified gateway account id.
+Returns the product only if it exists in the given gateway account. Useful to avoid insecure direct object reference.
 
 ```
-GET /v1/api/products?gatewayAccountId=1234
+GET /v1/api/gateway-account/1234/products/874h5c87834659q345698495
+```  
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+    "external_id": "874h5c87834659q345698495",
+    "description":         "Description of the product",
+    "price":               1050,
+    "return_url" :         "https://some.valid.url/"
+    "service_name":        "Some awesome government service",
+    "_links": [
+    {
+        "href": "https://govukpay-products.cloudapps.digital/v1/api/products/874h5c87834659q345698495",
+        "rel" : "self",
+        "method" : "GET"
+    },
+    {
+         "href": "https://govukpay-products-ui.cloudapps.digital/pay/874h5c87834659q345698495",
+         "rel" : "pay",
+         "method" : "POST"
+    }]
+}
+```
+#### Response field description 
+same as above(docs/api_specification.md#post-v1apiproducts)
+
+
+## GET /v1/api/gateway-account/{gatewayAccountId}/products
+
+This endpoint retrieves list of products that belongs to the specified gatewayAccountId.
+
+```
+GET /v1/api/gateway-account/1234/products
 ```  
 
 ### Response example
@@ -169,8 +206,68 @@ same as above(docs/api_specification.md#post-v1apiproducts)
 
 This endpoint disables a product with the specified external product id
 
+Deletes/Disables the product only if it exists in the given gateway account. Useful to avoid insecure direct object reference.
+
 ```
 PATCH /v1/api/products/uier837y735n837475y3847534/disable
+```  
+
+### Response example
+
+```
+204 OK
+``` 
+
+
+## GET /v1/api/payments/{paymentId}
+
+This endpoint finds a payment with the specified external payment id
+
+```
+GET /v1/api/payments/h6347634cwb67wii7b6ciueroytw
+```  
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+        "external_id": "h6347634cwb67wii7b6ciueroytw",
+        "next_url": "https://some.valid.url/paid",
+        "product_external_id": "uier837y735n837475y3847534",
+        "status": "CREATED",
+        "amount" : 1050,
+        "_links": [
+            {
+                "rel": "self",
+                "method": "GET",
+                "href": "https://govukpay-products.cloudapps.digital/v1/api/payments/h6347634cwb67wii7b6ciueroytw"
+            },
+            {
+                "rel": "next",
+                "method": "GET",
+                "href": "https://some.valid.url/paid"
+            } 
+        ]
+    }
+```
+#### Response field description 
+| Field                    | always present | Description                                   |
+| ------------------------ |:--------------:| --------------------------------------------- |
+| `external_id`            | X              | external id of the payment                |
+| `product_external_id `   | X              | product external id which owns this payment  |   |
+| `status`                 | X              | Status of the payment      |
+| `amount`                 | X              | amount of the payment in pence. |
+| `_links.self`            | X              | self GET link to the payment. |
+| `_links.next`            | X              | next GET link |
+
+## PATCH /v1/api/gateway-account/{gatewayAccountId}/products/{productExternalId}/disable
+
+This endpoint disables a product with the specified productExternalId that belongs to the gateway account specified by gatewayAccountId
+
+```
+PATCH /v1/api/gateway-account/1234/products/uier837y735n837475y3847534/disable
 ```  
 
 ### Response example
@@ -342,7 +439,7 @@ This endpoint batch updates Service Names of Products with a given gatewayAccoun
 ### Request example
 
 ```
-PATCH /v1/api/gateway-account/56
+PATCH /v1/api/gateway-account/1234
 Content-Type: application/json
 
 {

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -45,14 +45,11 @@ public class ProductResource {
 
     }
 
-    // TODO: TO BE REMOVED!
-    // Leaving this provisionally for backward compatibility
-    @Deprecated
     @GET
     @Path("/products/{productExternalId}")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response deprecatedFindProduct(@PathParam("productExternalId") String productExternalId) {
+    public Response findProductByExternalId(@PathParam("productExternalId") String productExternalId) {
         logger.info("Find a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().findByExternalId(productExternalId)
                 .map(product ->
@@ -65,7 +62,7 @@ public class ProductResource {
     @Path("/gateway-account/{gatewayAccountId}/products/{productExternalId}")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response findProduct(@PathParam("gatewayAccountId") Integer gatewayAccountId, @PathParam("productExternalId") String productExternalId) {
+    public Response findProductByGatewayAccountIdAndExternalId(@PathParam("gatewayAccountId") Integer gatewayAccountId, @PathParam("productExternalId") String productExternalId) {
         logger.info("Find a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().findByGatewayAccountIdAndExternalId(gatewayAccountId, productExternalId)
                 .map(product ->
@@ -74,14 +71,11 @@ public class ProductResource {
                         Response.status(NOT_FOUND).build());
     }
 
-    // TODO: TO BE REMOVED!
-    // Leaving this provisionally for backward compatibility
-    @Deprecated
     @PATCH
     @Path("/products/{productExternalId}/disable")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response deprecatedDisableProduct(@PathParam("productExternalId") String productExternalId) {
+    public Response disableProductByExternalId(@PathParam("productExternalId") String productExternalId) {
         logger.info("Disabling a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().disableByExternalId(productExternalId)
                 .map(product -> Response.status(NO_CONTENT).build())
@@ -92,29 +86,17 @@ public class ProductResource {
     @Path("/gateway-account/{gatewayAccountId}/products/{productExternalId}/disable")
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
-    public Response disableProduct(@PathParam("gatewayAccountId") Integer gatewayAccountId, @PathParam("productExternalId") String productExternalId) {
+    public Response disableProductByGatewayAccountIdAndExternalId(@PathParam("gatewayAccountId") Integer gatewayAccountId, @PathParam("productExternalId") String productExternalId) {
         logger.info("Disabling a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().disableByGatewayAccountIdAndExternalId(gatewayAccountId, productExternalId)
                 .map(product -> Response.status(NO_CONTENT).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
-    // TODO: TO BE REMOVED!
-    // Leaving this provisionally for backward compatibility
-    @Deprecated
-    @GET
-    @Path("/products")
-    @Produces(APPLICATION_JSON)
-    public Response deprecatedFindProducts(@QueryParam("gatewayAccountId") Integer gatewayAccountId) {
-        logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);
-        List<Product> products = productFactory.productFinder().findByGatewayAccountId(gatewayAccountId);
-        return Response.status(OK).entity(products).build();
-    }
-
     @GET
     @Path("/gateway-account/{gatewayAccountId}/products")
     @Produces(APPLICATION_JSON)
-    public Response findProducts(@PathParam("gatewayAccountId") Integer gatewayAccountId) {
+    public Response findProductsByGatewayAccountId(@PathParam("gatewayAccountId") Integer gatewayAccountId) {
         logger.info("Searching for products with gatewayAccountId - [ {} ]", gatewayAccountId);
         List<Product> products = productFactory.productFinder().findByGatewayAccountId(gatewayAccountId);
         return Response.status(OK).entity(products).build();


### PR DESCRIPTION
The new endpoints constraining all product operations by gateway accounts introduced in c49ca1e0abaac1386e3f4b2471a277a4fcda1b53, also deprecated the original endpoints. As it became apparent that the original endpoints were also needed, this change reinstates them and adds missing tests.

# NOTE
To be merged only after:
- https://github.com/alphagov/pay-selfservice/pull/703
- https://github.com/alphagov/pay-products-ui/pull/67