### PR TITLE
PP-3265 Jenkins jobs converted to use selenium style smoke tests for all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,36 @@ pipeline {
         branch 'master'
       }
       steps {
-        deployEcs("products", "test", null, true, true, "uk.gov.pay.endtoend.categories.SmokeProducts", true)
+        deployEcs("products", "test", null, false, false)
+      }
+    }
+    stage('Smoke Tests') {
+      when {
+        branch 'master'
+      }
+      steps {
+        runProductsSmokeTest()
+      }
+    }
+    stage('Complete') {
+      failFast true
+      parallel {
+        stage('Tag Build') {
+          when {
+            branch 'master'
+          }
+          steps {
+            tagDeployment("products")
+          }
+        }
+        stage('Trigger Deploy Notification') {
+          when {
+            branch 'master'
+          }
+          steps {
+            triggerGraphiteDeployEvent("products")
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Use new separate split out jobs for deployment, smoke tests, tagging and
deployment event notification
Updated deployEcs arguments not to run tests and tag

solo @belindac