### PR TITLE
PP-3425 Implementation of product update operation

### DIFF
--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -74,6 +74,7 @@ public class Product {
     }
 
     public static Product from(JsonNode jsonPayload) {
+        String externalId = (jsonPayload.get(EXTERNAL_ID) != null) ? jsonPayload.get(EXTERNAL_ID).asText() : randomUuid();
         String payApiToken = (jsonPayload.get(FIELD_PAY_API_TOKEN) != null) ? jsonPayload.get(FIELD_PAY_API_TOKEN).asText() : null;
         String name = (jsonPayload.get(FIELD_NAME) != null) ? jsonPayload.get(FIELD_NAME).asText() : null;
         Long price = (jsonPayload.get(FIELD_PRICE) != null) ? jsonPayload.get(FIELD_PRICE).asLong() : null;
@@ -85,7 +86,7 @@ public class Product {
         String serviceNamePath = (jsonPayload.get(FIELD_SERVICE_NAME_PATH) != null) ? jsonPayload.get(FIELD_SERVICE_NAME_PATH).asText() : null;
         String productNamePath = (jsonPayload.get(FIELD_PRODUCT_NAME_PATH) != null) ? jsonPayload.get(FIELD_PRODUCT_NAME_PATH).asText() : null;
 
-        return new Product(randomUuid(), name, description, payApiToken,
+        return new Product(externalId, name, description, payApiToken,
                 price, ProductStatus.ACTIVE, gatewayAccountId, serviceName, type, returnUrl,
                 serviceNamePath, productNamePath);
     }

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -13,7 +13,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.List;
-import java.util.Optional;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -112,6 +111,20 @@ public class ProductResource {
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
+    @PUT
+    @Path("/gateway-account/{gatewayAccountId}/products/{productExternalId}")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response updateProduct(@PathParam("gatewayAccountId") Integer gatewayAccountId, JsonNode payload) {
+        logger.info("Updating a product - [ {} ]", payload);
+        return requestValidator.validateCreateRequest(payload)
+                .map(errors -> Response.status(Status.BAD_REQUEST).entity(errors).build())
+                .orElseGet(() ->
+                    productFactory.productCreator().doUpdateByGatewayAccountId(gatewayAccountId, Product.from(payload))
+                            .map(product -> Response.status(OK).entity(product).build())
+                            .orElseGet(() -> Response.status(NOT_FOUND).build()));
+    }
+
     @DELETE
     @Path("/gateway-account/{gatewayAccountId}/products/{productExternalId}")
     @Produces(APPLICATION_JSON)
@@ -136,10 +149,10 @@ public class ProductResource {
     @Produces(APPLICATION_JSON)
     public Response findProductByProductPath(
             @QueryParam("serviceNamePath") String serviceNamePath,
-            @QueryParam("productNamePath") String productNamePath ) {
+            @QueryParam("productNamePath") String productNamePath) {
         logger.info(format("Searching for product with product path - [ serviceNamePath=%s productNamePath=%s ]", serviceNamePath, productNamePath));
         return productFactory.productFinder().findByProductPath(serviceNamePath, productNamePath)
-                    .map(product -> Response.status(OK).entity(product).build())
-                            .orElseGet(() -> Response.status(NOT_FOUND).build());
+                .map(product -> Response.status(OK).entity(product).build())
+                .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/ProductCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductCreator.java
@@ -6,6 +6,8 @@ import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
 
+import java.util.Optional;
+
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
 public class ProductCreator {
@@ -27,5 +29,18 @@ public class ProductCreator {
         productDao.persist(productEntity);
 
         return linksDecorator.decorate(productEntity.toProduct());
+    }
+
+    @Transactional
+    public Optional<Product> doUpdateByGatewayAccountId(Integer gatewayAccountId, Product product) {
+
+        return productDao
+                .findByGatewayAccountIdAndExternalId(gatewayAccountId, product.getExternalId())
+                .map(productEntity -> {
+                    productEntity.setName(product.getName());
+                    productEntity.setDescription(product.getDescription());
+                    productEntity.setPrice(product.getPrice());
+                    return linksDecorator.decorate(productEntity.toProduct());
+                });
     }
 }

--- a/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
+++ b/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
@@ -15,7 +15,7 @@ public class ProductEntityFixture {
     private String name = "default name";
     private String serviceName = "default service";
     private Long price = 100L;
-    private String returnUrl = "http://return.url";
+    private String returnUrl = "https://return.url";
     private ProductStatus status = ProductStatus.ACTIVE;
     private ProductType type = ProductType.DEMO;
     private String externalId = randomUuid();
@@ -51,6 +51,11 @@ public class ProductEntityFixture {
 
     public ProductEntityFixture withName(String name) {
         this.name = name;
+        return this;
+    }
+
+    public ProductEntityFixture withDescription(String description) {
+        this.description = description;
         return this;
     }
 


### PR DESCRIPTION
* A new service method allows to update a product record. Note that only the following 3 fields are updatable for now, all other fields passed in simply being ignored: `name`, `description` and `price`.

* A new endpoint [PUT] `/gateway-account/{gatewayAccountId}/products/{productExternalId}` exposes the product update functionality. A valid product must be specified in the payload of the operation where the fields `name`, `description` and `price` contains the new values to be updated. Upon successful update, the updated product is returned in the response. If no matching product can be found, [404] NOT FOUND is returned instead.