### PR TITLE
PP-3935: Upgrade Dropwizard from 1.2.2 to 1.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>1.2.2</dropwizard.version>
+        <dropwizard.version>1.2.7</dropwizard.version>
         <eclipselink.version>2.6.4</eclipselink.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
This upgrades Jackson from 2.9.1 to 2.9.6 and Jetty from 9.4.7.v20170914 to
9.4.10.v20180503