### PR TITLE
PP-4095 Ignore unknown properties when deserialising payment

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.products.client.publicapi;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -11,6 +12,7 @@ import uk.gov.pay.products.client.publicapi.model.RefundSummary;
 import uk.gov.pay.products.client.publicapi.model.SettlementSummary;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PaymentResponse {
     private String paymentId;
     private String paymentProvider;

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
@@ -100,6 +100,7 @@ public class PublicApiStub {
                                                 .add("href", "https://an.example.link/from/payment/platform")
                                                 .add("method", "GET")))
                 .add("card_brand", "Visa")
+                .add("Do not add this property to PaymentResponse", "To test deserialisation handles new/unknown properties")
                 .build();
     }
 


### PR DESCRIPTION
When deserialising a payment response from public API into a `PaymentResponse` object, ignore any unknown properties that are encountered in the JSON.

This makes it possible to add new properties to the payment responses returned by public API without having to modify this project.