### PR TITLE
PP-3926 Remove email and card details from PaymentResponse

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
@@ -193,11 +193,9 @@ public class PaymentResponse {
                 ", description='" + description + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +
-                ", email='" + email + '\'' +
                 ", createdDate='" + createdDate + '\'' +
                 ", refundSummary=" + refundSummary +
                 ", settlementSummary=" + settlementSummary +
-                ", cardDetails=" + cardDetails +
                 ", links=" + links +
                 ", cardBrand='" + cardBrand + '\'' +
                 '}';


### PR DESCRIPTION
Email and user address should never be logged, removing them from the `toString()` method should suffice