### PR TITLE
PP-4297 fix response objects to ignore unknown fields

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/Address.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/Address.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.client.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
 
     private String line1;

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/CardDetails.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.client.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CardDetails {
 
     private final String lastDigitsCardNumber;

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/Links.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/Links.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.client.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Links {
 
     private Link self;

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/PaymentState.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.client.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PaymentState {
     private String status;
     private boolean finished;

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/RefundSummary.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.client.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundSummary {
 
     private String status;

--- a/src/main/java/uk/gov/pay/products/client/publicapi/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/model/SettlementSummary.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.client.publicapi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SettlementSummary {
 
     private String captureSubmitTime;


### PR DESCRIPTION
## WHAT
Fix response objects to ignore unknown fields. This is needed as we're extending publicapi responses and they're breaking products.

## HOW
add `@JsonIgnoreProperties(ignoreUnknown = true)` to relevant classes