### PR TITLE
PP-4378: Use --no-cache with apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM govukpay/openjdk:alpine-3.8.1-jre-8.181.13
 
-RUN apk update
-RUN apk upgrade
+RUN apk --no-cache upgrade
 
-RUN apk add bash
+RUN apk --no-cache add bash
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081


### PR DESCRIPTION
When building our images, using the --no-cache argument to Alpine's package
manager, apk, avoids saving package listings to disk. This reduces the size of
our docker images slightly.