### PR TITLE
BAU: Add Dependency-Check Maven Plugin 3.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,18 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>3.3.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This can be used to scan dependencies for security vulnerabilities.

```
$ mvn help:describe -Dplugin=org.owasp:dependency-check-maven

… some output omitted …

Name: Dependency-Check Maven Plugin
Description: dependency-check-maven is a Maven Plugin that uses
  dependency-check-core to detect publicly disclosed vulnerabilities associated
  with the project's dependencies. The plugin will generate a report listing
  the dependency, any identified Common Platform Enumeration (CPE) identifiers,
  and the associated Common Vulnerability and Exposure (CVE) entries.
Group Id: org.owasp
Artifact Id: dependency-check-maven
Version: 3.3.4
Goal Prefix: dependency-check

This plugin has 5 goals:

dependency-check:aggregate
  Description: Maven Plugin that checks project dependencies and the
    dependencies of all child modules to see if they have any known published
    vulnerabilities.
  Note: This goal should be used as a Maven report.

dependency-check:check
  Description: Maven Plugin that checks the project dependencies to see if
    they have any known published vulnerabilities.
  Note: This goal should be used as a Maven report.

dependency-check:help
  Description: Display help information on dependency-check-maven.
    Call mvn dependency-check:help -Ddetail=true -Dgoal=<goal-name> to display
    parameter details.

dependency-check:purge
  Description: Maven Plugin that purges the local copy of the NVD data.
  Note: This goal should be used as a Maven report.

dependency-check:update-only
  Description: Maven Plugin that updates the local cache of the NVD data from
    NIST.
  Note: This goal should be used as a Maven report.

For more information, run 'mvn help:describe [...] -Ddetail'
```