### PR TITLE
BAU: Remove unneccessary config from logback.xml

### DIFF
--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-
-    <logger name="org.apache.http" level="info"
-            additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
+    <logger name="org.apache.http" level="info" />
 </configuration>


### PR DESCRIPTION
# WHAT

Yesterday we added in a logback.xml to stop the apache httpclient library defaulting to DEBUG logging level. After that Russell noticed a couple of ERRORs in the log:

```
08:34:55,946 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - Could not find an appender named [STDOUT]. Did you define it below instead of above in the configuration file?
08:34:55,946 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction - See http://logback.qos.ch/codes.html#appender_order for more details.
```

We actually don't need to set appender-ref and additivity. In fact, setting appender-ref to STDOUT is causing error in log. So this change set is to remove the redundant configs.

# HOW WAS IT TESTED 
Ran `mvn clean test` locally and the errors no longer happened.