### PR TITLE
Silence liquibase noise during tests

### DIFF
--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -14,6 +14,9 @@ logging:
       timeZone: UTC
       target: stdout
       logFormat: "[%X{X-Request-Id}] - [%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+  loggers:
+    # Liquibase is very chatty and we only want to hear from it if things go wrong
+    "liquibase": WARN
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}


### PR DESCRIPTION
Downgrade the logging level of liquibase during test runs. Liquibase logs all
its SQL which clutters the build log.