### PR TITLE
BAU: More IntelliJ-inspired tidyups

### DIFF
--- a/src/main/java/uk/gov/pay/products/healthchecks/DatabaseHealthCheck.java
+++ b/src/main/java/uk/gov/pay/products/healthchecks/DatabaseHealthCheck.java
@@ -24,22 +24,21 @@ public class DatabaseHealthCheck extends HealthCheck {
     private Integer statsHealthy = 0;
 
     static {
-        longDatabaseStatsMap = new HashMap<String, Long>();
-        longDatabaseStatsMap.put("numbackends", 0l);
-        longDatabaseStatsMap.put("numbackends", 0l);
-        longDatabaseStatsMap.put("xact_commit", 0l);
-        longDatabaseStatsMap.put("xact_rollback", 0l);
-        longDatabaseStatsMap.put("blks_read", 0l);
-        longDatabaseStatsMap.put("blks_hit", 0l);
-        longDatabaseStatsMap.put("tup_returned", 0l);
-        longDatabaseStatsMap.put("tup_fetched", 0l);
-        longDatabaseStatsMap.put("tup_inserted", 0l);
-        longDatabaseStatsMap.put("tup_updated", 0l);
-        longDatabaseStatsMap.put("tup_deleted", 0l);
-        longDatabaseStatsMap.put("conflicts", 0l);
-        longDatabaseStatsMap.put("temp_files", 0l);
-        longDatabaseStatsMap.put("temp_bytes", 0l);
-        longDatabaseStatsMap.put("deadlocks", 0l);
+        longDatabaseStatsMap = new HashMap<>();
+        longDatabaseStatsMap.put("numbackends", 0L);
+        longDatabaseStatsMap.put("xact_commit", 0L);
+        longDatabaseStatsMap.put("xact_rollback", 0L);
+        longDatabaseStatsMap.put("blks_read", 0L);
+        longDatabaseStatsMap.put("blks_hit", 0L);
+        longDatabaseStatsMap.put("tup_returned", 0L);
+        longDatabaseStatsMap.put("tup_fetched", 0L);
+        longDatabaseStatsMap.put("tup_inserted", 0L);
+        longDatabaseStatsMap.put("tup_updated", 0L);
+        longDatabaseStatsMap.put("tup_deleted", 0L);
+        longDatabaseStatsMap.put("conflicts", 0L);
+        longDatabaseStatsMap.put("temp_files", 0L);
+        longDatabaseStatsMap.put("temp_bytes", 0L);
+        longDatabaseStatsMap.put("deadlocks", 0L);
         doubleDatabaseStatsMap = new HashMap<>();
         doubleDatabaseStatsMap.put("blk_read_time", 0.0);
         doubleDatabaseStatsMap.put("blk_write_time", 0.0);
@@ -64,19 +63,13 @@ public class DatabaseHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
-        Connection connection = null;
-        try {
-            connection = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
+    protected Result check() {
+        try (Connection connection = DriverManager.getConnection(dbUrl, dbUser, dbPassword)) {
             connection.setReadOnly(true);
             updateMetricData(connection);
             return connection.isValid(2) ? Result.healthy() : Result.unhealthy("Could not validate the DB connection.");
         } catch (Exception e) {
             return Result.unhealthy(e.getMessage());
-        } finally {
-            if (connection != null) {
-                connection.close();
-            }
         }
     }
 

--- a/src/test/java/uk/gov/pay/products/infra/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/products/infra/DropwizardAppWithPostgresRule.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.products.infra;
 
-import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -24,7 +23,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Properties;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static io.dropwizard.testing.ConfigOverride.config;
@@ -32,7 +30,6 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 public class DropwizardAppWithPostgresRule implements TestRule {
     private static final Logger logger = LoggerFactory.getLogger(DropwizardAppWithPostgresRule.class);
-    private static final String JPA_UNIT = "ProductsUnit";
 
     private final String configFilePath;
     private final PostgresDockerRule postgres;
@@ -58,7 +55,6 @@ public class DropwizardAppWithPostgresRule implements TestRule {
                 configFilePath,
                 cfgOverrideList.toArray(new ConfigOverride[cfgOverrideList.size()])
         );
-        createJpaModule(postgres);
         rules = RuleChain.outerRule(postgres).around(app);
         registerShutdownHook();
     }
@@ -105,19 +101,6 @@ public class DropwizardAppWithPostgresRule implements TestRule {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             postgres.stop();
         }));
-    }
-
-    private JpaPersistModule createJpaModule(final PostgresDockerRule postgres) {
-        final Properties properties = new Properties();
-        properties.put("javax.persistence.jdbc.driver", postgres.getDriverClass());
-        properties.put("javax.persistence.jdbc.url", postgres.getConnectionUrl());
-        properties.put("javax.persistence.jdbc.user", postgres.getUsername());
-        properties.put("javax.persistence.jdbc.password", postgres.getPassword());
-
-        final JpaPersistModule jpaModule = new JpaPersistModule(JPA_UNIT);
-        jpaModule.properties(properties);
-
-        return jpaModule;
     }
 
     private void restoreDropwizardsLogging() {

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
@@ -14,7 +14,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.mockserver.model.HttpRequest.request;
 
 public class PublicApiStub {
-    public static final String API_VERSION_PATH = "/v1";
+    private static final String API_VERSION_PATH = "/v1";
     private static final String PAYMENTS_PATH = API_VERSION_PATH + "/payments";
     private static final String PAYMENT_PATH = PAYMENTS_PATH + "/%s";
 
@@ -52,8 +52,8 @@ public class PublicApiStub {
                 .add("refund_summary",
                         Json.createObjectBuilder()
                                 .add("status", "available")
-                                .add("amount_available", 1000l)
-                                .add("amount_submitted", 2000l))
+                                .add("amount_available", 1000L)
+                                .add("amount_submitted", 2000L))
                 .add("settlement_summary",
                         Json.createObjectBuilder()
                                 .add("capture_submit_time", "2016-01-21T17:15:00Z")


### PR DESCRIPTION
* Use try with resources to manage the lifecycle of JDBC `Connection` objects
* Use IntelliJ's preferred `L` designator for `long` literals
* Remove an unused constructor in `DropwizardAppWithPostgresRule`
* Tighten a couple of access levels
* Turn an unused field into a method variable