### PR TITLE
PP-4660, PP-4602: Use simpler database polling code, cleanup logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>
         <powermock.version>1.7.4</powermock.version>
         <jackson.version>2.9.8</jackson.version>
-        <pay-java-commons.version>1.0.20190116171117</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190118181040</pay-java-commons.version>
         <dependency-check.skip>true</dependency-check.skip>
     </properties>
 

--- a/src/main/java/uk/gov/pay/products/healthchecks/DependentResourceWaitCommand.java
+++ b/src/main/java/uk/gov/pay/products/healthchecks/DependentResourceWaitCommand.java
@@ -21,12 +21,7 @@ public class DependentResourceWaitCommand extends ConfiguredCommand<ProductsConf
 
     @Override
     protected void run(Bootstrap<ProductsConfiguration> bs, Namespace ns, ProductsConfiguration conf) {
-        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()), duration -> {
-            try {
-                Thread.sleep(duration.toNanos() / 1000);
-            } catch (InterruptedException ignored) {
-            }
-        })
+        new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()))
                 .checkAndWaitForResource();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
       threshold: ALL
       timeZone: UTC
       target: stdout
-      logFormat: "[%X{X-Request-Id}] - [%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -13,7 +13,7 @@ logging:
       threshold: ALL
       timeZone: UTC
       target: stdout
-      logFormat: "[%X{X-Request-Id}] - [%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
   loggers:
     # Liquibase is very chatty and we only want to hear from it if things go wrong
     "liquibase": WARN


### PR DESCRIPTION
## WHAT YOU DID
Change the log format to match other microservices. Remove ANSI colours and trailing whitespace.

Also use the new single-argument constructor for `ApplicationStartupDependentResourceChecker` in `DependentResourceWaitCommand`