### PR TITLE
Avoid Mockito deprecation warning

### DIFF
--- a/src/test/java/uk/gov/pay/products/filters/RestClientLoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/products/filters/RestClientLoggingFilterTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 


### PR DESCRIPTION
Mockito has deprecated org.mockito.runners.MockitoJUnitRunner in favour of
org.mockito.junit.MockitoJUnitRunner

This was already updated in all our tests apart from
RestClientLoggingFilterTest