### PR TITLE
PP-4954 Make PowerMock ignore classes it cannot load.

### DIFF
--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -7,6 +7,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import uk.gov.pay.products.client.publicapi.PaymentRequest;
@@ -48,6 +49,7 @@ import static uk.gov.pay.products.util.RandomIdGenerator.randomUserFriendlyRefer
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*"})
 @PrepareForTest(RandomIdGenerator.class)
 public class PaymentCreatorTest {
     static private final String PRODUCT_URL = "https://products.url";


### PR DESCRIPTION
Prevent Powermock from attempting to load particular classes which would result in illegal access and failure to compile. This is necessary for Java 11 upgrade.

## WHAT YOU DID
Add an annotation that tells Powermock to ignore attempting to load particular classes. Without this post java 8, in this particular instance it attempts to illegally access `javax.xml.parsers.FactoryFinder` when mocking our `PublicApiRestClient`. 