### PR TITLE
PP-4987 Add language field to product

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -23,6 +23,7 @@ Content-Type: application/json
     "reference_enabled":        "true",
     "reference_label":          "Reference label",
     "reference_hint":           "Hint for the above reference"
+    "language":                 "The language pages for the product will be in"
 }
 ```
 
@@ -41,6 +42,7 @@ Content-Type: application/json
 | `reference_enabled`      |    X     | Flag to set whether payment reference is auto generated or entered by user. True means that user enters reference at the beginning of a user journey.   |   |
 | `reference_label`        |    O     | Only required if `reference_enabled` is true. Label for the reference entry text box.   |   |
 | `reference_hint`         |          | Hint text for reference entry text box. Optional field when reference enabled. Ignored if `reference_enabled` is set to false. |   |
+| `language`               |          | The language pages for the product will be in. If not provided, defaults to 'en' | 'en', 'cy'          |
 
 ### Response example
 
@@ -52,11 +54,12 @@ Content-Type: application/json
     "gateway_account_id" : "1234",
     "description":         "Description of the product",
     "price":               1050,
-    "type":                "DEMO,
+    "type":                "DEMO",
     "return_url" :         "https://some.valid.url/",
     "reference_enabled":   "true",
     "reference_label":     "Amount for your licence",
-    "reference_hint":     "This can be found on your letter",
+    "reference_hint":      "This can be found on your letter",
+    "language":            "en"
     "_links": [
     {
         "href": "https://govukpay-products.cloudapps.digital/v1/api/products/874h5c87834659q345698495",
@@ -91,6 +94,7 @@ Content-Type: application/json
 | `reference_enabled`      | X              | The settings for auto generated (false) or user entry (true) payment reference.   |
 | `reference_label`        |                | Present when `reference_enabled` is true. Label text for the reference entry box. |
 | `reference_hint`         |                | Hint for the `reference_enabled` text box. Optional field when reference enabled. |
+| `language`               | X              | The language to display pages for the product in |
 
 ## PATCH /v1/api/gateway-account/{gatewayAccountId}/products/{productId}
 

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -6,11 +6,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
@@ -63,13 +67,26 @@ public class Product {
     private final String referenceLabel;
     @JsonProperty(FIELD_REFERENCE_HINT)
     private final String referenceHint;
+    @JsonProperty(FIELD_LANGUAGE)
+    @JsonSerialize(using = ToStringSerializer.class)
+    private final SupportedLanguage language;
 
-    public Product(String externalId, String name, String description, String payApiToken, Long price, 
-                   ProductStatus status, Integer gatewayAccountId, ProductType type,
-                   String returnUrl, String serviceNamePath, String productNamePath)
-    {
-        this(externalId, name, description, payApiToken, price, status, gatewayAccountId, type,
-                returnUrl, serviceNamePath, productNamePath, false, null, null);
+
+    public Product(String externalId,
+                   String name,
+                   String description,
+                   String payApiToken,
+                   Long price,
+                   ProductStatus status,
+                   Integer gatewayAccountId,
+                   ProductType type,
+                   String returnUrl,
+                   String serviceNamePath,
+                   String productNamePath,
+                   SupportedLanguage language) {
+        this(externalId, name, description, payApiToken, price, status, gatewayAccountId, type, returnUrl,
+                serviceNamePath, productNamePath, false, null, null,
+                language);
     }
 
     public Product(
@@ -86,8 +103,8 @@ public class Product {
             String productNamePath,
             Boolean referenceEnabled,
             String referenceLabel,
-            String referenceHint)
-    {
+            String referenceHint,
+            SupportedLanguage language) {
         this.externalId = externalId;
         this.name = name;
         this.description = description;
@@ -102,6 +119,7 @@ public class Product {
         this.referenceEnabled = referenceEnabled;
         this.referenceLabel = referenceLabel;
         this.referenceHint = referenceHint;
+        this.language = language;
     }
 
     public static Product from(JsonNode jsonPayload) {
@@ -119,9 +137,14 @@ public class Product {
         String referenceLabel = (jsonPayload.get(FIELD_REFERENCE_LABEL) != null) ? jsonPayload.get(FIELD_REFERENCE_LABEL).asText() : null;
         String referenceHint = (jsonPayload.get(FIELD_REFERENCE_HINT) != null) ? jsonPayload.get(FIELD_REFERENCE_HINT).asText() : null;
         
-        return new Product(externalId, name, description, payApiToken,
-                price, ProductStatus.ACTIVE, gatewayAccountId, type, returnUrl,
-                serviceNamePath, productNamePath, referenceEnabled, referenceLabel, referenceHint);
+        SupportedLanguage language = Optional.ofNullable(jsonPayload.get(FIELD_LANGUAGE))
+                .map(JsonNode::asText)
+                .map(SupportedLanguage::fromIso639AlphaTwoCode)
+                .orElse(SupportedLanguage.ENGLISH);
+
+        return new Product(externalId, name, description, payApiToken, price, ProductStatus.ACTIVE, gatewayAccountId,
+                type, returnUrl, serviceNamePath, productNamePath, referenceEnabled, referenceLabel, referenceHint,
+                language);
     }
 
     public String getName() {
@@ -145,7 +168,9 @@ public class Product {
         return status;
     }
 
-    public Integer getGatewayAccountId() { return gatewayAccountId; }
+    public Integer getGatewayAccountId() {
+        return gatewayAccountId;
+    }
 
     public String getExternalId() {
         return externalId;
@@ -168,15 +193,29 @@ public class Product {
         return returnUrl;
     }
 
-    public String getServiceNamePath() { return serviceNamePath; }
+    public String getServiceNamePath() {
+        return serviceNamePath;
+    }
 
-    public String getProductNamePath() { return productNamePath; }
+    public String getProductNamePath() {
+        return productNamePath;
+    }
 
-    public Boolean getReferenceEnabled() { return referenceEnabled; }
-    
-    public String getReferenceLabel() { return referenceLabel; }
-    
-    public String getReferenceHint() { return referenceHint; }
+    public Boolean getReferenceEnabled() {
+        return referenceEnabled;
+    }
+
+    public String getReferenceLabel() {
+        return referenceLabel;
+    }
+
+    public String getReferenceHint() {
+        return referenceHint;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
 
     @Override
     public String toString() {
@@ -195,6 +234,7 @@ public class Product {
                 ", referenceEnabled='" + referenceEnabled +
                 (referenceEnabled ? '\'' + ", referenceLabel='" + referenceLabel : "") +
                 (referenceEnabled ? '\'' + ", referenceHint='" + referenceHint : "") +
+                ", language='" + language + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
@@ -1,10 +1,17 @@
 package uk.gov.pay.products.persistence.entity;
 
+import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -59,6 +66,10 @@ public class ProductEntity extends AbstractEntity {
     
     @Column(name = "reference_hint")
     private String referenceHint;
+    
+    @Column(name = "language", nullable = false)
+    @Convert(converter = SupportedLanguageJpaConverter.class)
+    private SupportedLanguage language;
 
     public ProductEntity() {
     }
@@ -163,6 +174,14 @@ public class ProductEntity extends AbstractEntity {
 
     public void setProductNamePath(String productNamePath) { this.productNamePath = productNamePath; }
 
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(SupportedLanguage language) {
+        this.language = language;
+    }
+
     public static ProductEntity from(Product product) {
         ProductEntity productEntity = new ProductEntity();
 
@@ -180,6 +199,7 @@ public class ProductEntity extends AbstractEntity {
         productEntity.setReferenceEnabled(product.getReferenceEnabled());
         productEntity.setReferenceLabel(product.getReferenceLabel());
         productEntity.setReferenceHint(product.getReferenceHint());
+        productEntity.setLanguage(product.getLanguage());
 
         return productEntity;
     }
@@ -199,6 +219,7 @@ public class ProductEntity extends AbstractEntity {
                 this.productNamePath,
                 this.referenceEnabled,
                 this.referenceLabel,
-                this.referenceHint);
+                this.referenceHint,
+                this.language);
     }
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,6 +2,7 @@
 <persistence version="2.1" xmlns="http://java.sun.com/xml/ns/persistence">
     <persistence-unit name="ProductsUnit" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>uk.gov.pay.commons.model.SupportedLanguageJpaConverter</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
     </persistence-unit>
 </persistence>

--- a/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
+++ b/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.products.fixtures;
 
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
 import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
@@ -24,6 +25,7 @@ public class ProductEntityFixture {
     private Boolean referenceEnabled = false;
     private String referenceLabel;
     private String referenceHint;
+    private SupportedLanguage language = SupportedLanguage.ENGLISH;
 
     private ProductEntityFixture() { }
 
@@ -44,6 +46,7 @@ public class ProductEntityFixture {
         product.setReferenceEnabled(referenceEnabled);
         product.setReferenceLabel(referenceLabel);
         product.setReferenceHint(referenceHint);
+        product.setLanguage(language);
 
         return product;
     }
@@ -110,6 +113,11 @@ public class ProductEntityFixture {
 
     public ProductEntityFixture withPrice(long price) {
         this.price = price;
+        return this;
+    }
+    
+    public ProductEntityFixture withLanguage(SupportedLanguage language) {
+        this.language = language;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Assert;
 import org.junit.Test;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.fixtures.ProductEntityFixture;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.util.ProductStatus;
@@ -40,6 +41,7 @@ public class ProductResourceTest extends IntegrationTest {
     private static final String REFERENCE_ENABLED_FIELD = "reference_enabled";
     private static final String REFERENCE_LABEL = "reference_label";
     private static final String REFERENCE_HINT = "reference_hint";
+    private static final String LANGUAGE = "language";
 
     @Test
     public void shouldSuccess_whenSavingAValidProduct_withMinimumMandatoryFields() throws Exception {
@@ -72,7 +74,8 @@ public class ProductResourceTest extends IntegrationTest {
                 .body(GATEWAY_ACCOUNT_ID, is(gatewayAccountId))
                 .body(PRICE, is(1050))
                 .body(EXTERNAL_ID, matchesPattern("^[0-9a-z]{32}$"))
-                .body(TYPE, is(type));
+                .body(TYPE, is(type))
+                .body(LANGUAGE, is("en"));
 
         String externalId = response.extract().path(EXTERNAL_ID);
 
@@ -99,9 +102,9 @@ public class ProductResourceTest extends IntegrationTest {
         String type = ProductType.ADHOC.name();
         String serviceNamePath = randomAlphanumeric(40);
         String productNamePath = randomAlphanumeric(65);
-
         String returnUrl = "https://some.valid.url";
-
+        String language = "cy";
+        
         ImmutableMap<String, String> payload = ImmutableMap.<String, String>builder()
                 .put(GATEWAY_ACCOUNT_ID, gatewayAccountId.toString())
                 .put(PAY_API_TOKEN, payApiToken)
@@ -113,6 +116,7 @@ public class ProductResourceTest extends IntegrationTest {
                 .put(SERVICE_NAME_PATH, serviceNamePath)
                 .put(PRODUCT_NAME_PATH, productNamePath)
                 .put(REFERENCE_ENABLED_FIELD, Boolean.FALSE.toString())
+                .put(LANGUAGE, language)
                 .build();
 
         ValidatableResponse response = givenSetup()
@@ -130,7 +134,8 @@ public class ProductResourceTest extends IntegrationTest {
                 .body(TYPE, is(type))
                 .body(DESCRIPTION, is(description))
                 .body(RETURN_URL, is(returnUrl))
-                .body(REFERENCE_ENABLED_FIELD, is(false));
+                .body(REFERENCE_ENABLED_FIELD, is(false))
+                .body(LANGUAGE, is(language));
 
         String externalId = response.extract().path(EXTERNAL_ID);
 
@@ -164,9 +169,9 @@ public class ProductResourceTest extends IntegrationTest {
         String productNamePath = randomAlphanumeric(65);
         String referenceLabel = randomAlphanumeric(25);
         String referenceHint = randomAlphanumeric(85);
-
         String returnUrl = "https://some.valid.url";
-
+        String language = "en";
+        
         ImmutableMap<String, String> payload = ImmutableMap.<String, String>builder()
                 .put(GATEWAY_ACCOUNT_ID, gatewayAccountId.toString())
                 .put(PAY_API_TOKEN, payApiToken)
@@ -180,6 +185,7 @@ public class ProductResourceTest extends IntegrationTest {
                 .put(REFERENCE_ENABLED_FIELD, Boolean.TRUE.toString())
                 .put(REFERENCE_LABEL, referenceLabel)
                 .put(REFERENCE_HINT, referenceHint)
+                .put(LANGUAGE, language)
                 .build();
 
         ValidatableResponse response = givenSetup()
@@ -199,7 +205,8 @@ public class ProductResourceTest extends IntegrationTest {
                 .body(RETURN_URL, is(returnUrl))
                 .body(REFERENCE_ENABLED_FIELD, is(true))
                 .body(REFERENCE_LABEL, is(referenceLabel))
-                .body(REFERENCE_HINT, is(referenceHint));
+                .body(REFERENCE_HINT, is(referenceHint))
+                .body(LANGUAGE, is(language));
 
         String externalId = response.extract().path(EXTERNAL_ID);
 
@@ -359,7 +366,8 @@ public class ProductResourceTest extends IntegrationTest {
                 .body(GATEWAY_ACCOUNT_ID, is(gatewayAccountId))
                 .body(TYPE, is(product.getType().name()))
                 .body(DESCRIPTION, is(product.getDescription()))
-                .body(RETURN_URL, is(product.getReturnUrl()));
+                .body(RETURN_URL, is(product.getReturnUrl()))
+                .body(LANGUAGE, is("en"));
 
         String productsUrl = "https://products.url/v1/api/products/";
         String productsUIPayUrl = "https://products-ui.url/pay/";
@@ -455,7 +463,8 @@ public class ProductResourceTest extends IntegrationTest {
                 .body(PRICE, is(Integer.valueOf(updatedPrice)))
                 .body(TYPE, is(existingProduct.getType().name()))
                 .body(GATEWAY_ACCOUNT_ID, is(gatewayAccountId))
-                .body(RETURN_URL, is(existingProduct.getReturnUrl()));
+                .body(RETURN_URL, is(existingProduct.getReturnUrl()))
+                .body(LANGUAGE, is("en"));
 
         String productsUrl = "https://products.url/v1/api/products/";
         String productsUIPayUrl = "https://products-ui.url/pay/";
@@ -699,6 +708,7 @@ public class ProductResourceTest extends IntegrationTest {
                 .withType(ProductType.ADHOC)
                 .withPrice(1000)
                 .withProductPath(serviceNamePath, productNamePath)
+                .withLanguage(SupportedLanguage.WELSH)
                 .build()
                 .toProduct();
 
@@ -718,7 +728,8 @@ public class ProductResourceTest extends IntegrationTest {
                 .body("_links", hasSize(3))
                 .body("_links[2].href", is(urlToMatch))
                 .body("_links[2].method", is(HttpMethod.GET))
-                .body("_links[2].rel", is("friendly"));
+                .body("_links[2].rel", is("friendly"))
+                .body(LANGUAGE, is("cy"));
 
 
     }

--- a/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductCreatorTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.matchers.ProductMatcher;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.dao.ProductDao;
@@ -35,7 +36,6 @@ public class ProductCreatorTest {
     private Integer gatewayAccountId = randomInt();
     private static final String PRODUCT_NAME = "Test product name";
     private static final Long PRICE = 1050L;
-    private static final String SERVICE_NAME = "Example Service";
 
     @Before
     public void setup() {
@@ -58,7 +58,8 @@ public class ProductCreatorTest {
                 ProductType.DEMO,
                 null,
                 null,
-                null
+                null,
+                SupportedLanguage.ENGLISH
         );
 
         Product product = productCreator.doCreate(basicProduct);
@@ -79,6 +80,7 @@ public class ProductCreatorTest {
         assertThat(productEntity.getGatewayAccountId(), is(gatewayAccountId));
         assertThat(productEntity.getType(), is(notNullValue()));
         assertThat(productEntity.getType(), is(ProductType.DEMO));
+        assertThat(productEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
 
     @Test
@@ -99,7 +101,8 @@ public class ProductCreatorTest {
                 ProductType.DEMO,
                 returnUrl,
                 serviceNamePath,
-                productNamePath
+                productNamePath,
+                SupportedLanguage.ENGLISH
         );
 
         Product product = productCreator.doCreate(productRequest);
@@ -131,7 +134,8 @@ public class ProductCreatorTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                SupportedLanguage.ENGLISH
         );
 
         ProductEntity mockedProductEntity = mock(ProductEntity.class);
@@ -169,7 +173,8 @@ public class ProductCreatorTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                SupportedLanguage.ENGLISH
         );
 
         when(productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -19,12 +19,13 @@ public class DatabaseTestHelper {
         jdbi.withHandle(handle -> handle.createStatement("INSERT INTO products " +
                 "(external_id, name, description, pay_api_token, price, " +
                 "status, return_url, type, gateway_account_id, " +
-                "service_name_path, product_name_path, reference_enabled, reference_label, reference_hint) " +
+                "service_name_path, product_name_path, reference_enabled, " +
+                "reference_label, reference_hint, language) " +
                 "VALUES " +
                 "(:external_id, :name, :description, :pay_api_token, :price, " +
                 ":status, :return_url, :type, :gateway_account_id, " +
                 ":service_name_path, :product_name_path, :reference_enabled, " + 
-                ":reference_label, :reference_hint" +
+                ":reference_label, :reference_hint, :language" +
                 ")")
                 .bind("external_id", product.getExternalId())
                 .bind("name", product.getName())
@@ -40,6 +41,7 @@ public class DatabaseTestHelper {
                 .bind("reference_enabled", product.getReferenceEnabled())
                 .bind("reference_label", product.getReferenceLabel())
                 .bind("reference_hint", product.getReferenceHint())
+                .bind("language", product.getLanguage().toString())
                 .execute());
 
     }


### PR DESCRIPTION
Add language field to ProductEntity and Product so that it is accepted by the create product endpoint, persisted to the database, and returned by the get product endpoints.

Default language to "en" when deserialising Product from JSON payload if the field is not present.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
