### PR TITLE
PP-5004 Send product language when creating a payment

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentRequest.java
@@ -3,6 +3,9 @@ package uk.gov.pay.products.client.publicapi;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class PaymentRequest {
@@ -11,16 +14,19 @@ public class PaymentRequest {
     private String reference;
     private String description;
     private String returnUrl;
+    private SupportedLanguage language;
 
     public PaymentRequest(
             @JsonProperty("amount") long amount,
             @JsonProperty("reference") String reference,
             @JsonProperty("description") String description,
-            @JsonProperty("return_url") String returnUrl) {
+            @JsonProperty("return_url") String returnUrl,
+            @JsonProperty("language") @JsonSerialize(using = ToStringSerializer.class) SupportedLanguage language) {
         this.amount = amount;
         this.reference = reference;
         this.description = description;
         this.returnUrl = returnUrl;
+        this.language = language;
     }
 
     public long getAmount() {
@@ -55,6 +61,14 @@ public class PaymentRequest {
         this.returnUrl = returnUrl;
     }
 
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(SupportedLanguage language) {
+        this.language = language;
+    }
+
     @Override
     public String toString() {
         return "PaymentRequest{" +
@@ -62,6 +76,7 @@ public class PaymentRequest {
                 ", reference='" + reference + '\'' +
                 ", description='" + description + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
+                ", language='" + language + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentRequest.java
@@ -76,7 +76,7 @@ public class PaymentRequest {
                 ", reference='" + reference + '\'' +
                 ", description='" + description + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
-                ", language='" + language + '\'' +
+                ", language='" + language.toString() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
@@ -3,7 +3,10 @@ package uk.gov.pay.products.client.publicapi;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.SupportedLanguageJsonDeserializer;
 import uk.gov.pay.products.client.publicapi.model.CardBrand;
 import uk.gov.pay.products.client.publicapi.model.CardDetails;
 import uk.gov.pay.products.client.publicapi.model.Links;
@@ -16,26 +19,19 @@ import uk.gov.pay.products.client.publicapi.model.SettlementSummary;
 public class PaymentResponse {
     private String paymentId;
     private String paymentProvider;
-
     private long amount;
     private PaymentState state;
     private String description;
-
     private String returnUrl;
     private String reference;
     private String email;
-
     private String createdDate;
-
     private RefundSummary refundSummary;
-
     private SettlementSummary settlementSummary;
-
     private CardDetails cardDetails;
-
     private Links links;
-
     private CardBrand cardBrand;
+    private SupportedLanguage language;
 
     public PaymentResponse() {
     }
@@ -54,7 +50,8 @@ public class PaymentResponse {
             @JsonProperty("settlement_summary") SettlementSummary settlementSummary,
             @JsonProperty("card_details") CardDetails cardDetails,
             @JsonProperty("_links") Links links,
-            @JsonProperty("card_brand") CardBrand cardBrand) {
+            @JsonProperty("card_brand") CardBrand cardBrand,
+            @JsonProperty("language") @JsonDeserialize(using = SupportedLanguageJsonDeserializer.class) SupportedLanguage language) {
         this.paymentId = paymentId;
         this.amount = amount;
         this.state = state;
@@ -67,8 +64,9 @@ public class PaymentResponse {
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
-        this.links= links;
+        this.links = links;
         this.cardBrand = cardBrand;
+        this.language = language;
     }
 
     public String getPaymentId() {
@@ -183,6 +181,14 @@ public class PaymentResponse {
         this.cardBrand = cardBrand;
     }
 
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(SupportedLanguage language) {
+        this.language = language;
+    }
+
     @Override
     public String toString() {
         return "PaymentResponse{" +
@@ -198,6 +204,7 @@ public class PaymentResponse {
                 ", settlementSummary=" + settlementSummary +
                 ", links=" + links +
                 ", cardBrand='" + cardBrand + '\'' +
+                ", language='" + language + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentResponse.java
@@ -204,7 +204,7 @@ public class PaymentResponse {
                 ", settlementSummary=" + settlementSummary +
                 ", links=" + links +
                 ", cardBrand='" + cardBrand + '\'' +
-                ", language='" + language + '\'' +
+                ", language='" + language.toString() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -234,7 +234,7 @@ public class Product {
                 ", referenceEnabled='" + referenceEnabled +
                 (referenceEnabled ? '\'' + ", referenceLabel='" + referenceLabel : "") +
                 (referenceEnabled ? '\'' + ", referenceHint='" + referenceHint : "") +
-                ", language='" + language + '\'' +
+                ", language='" + language.toString() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -116,7 +116,8 @@ public class PaymentCreator {
                     paymentPrice,
                     paymentEntity.getReferenceNumber(),
                     productEntity.getName(),
-                    returnUrl);
+                    returnUrl,
+                    productEntity.getLanguage());
 
             try {
                 PaymentResponse paymentResponse = publicApiRestClient.createPayment(productEntity.getPayApiToken(), paymentRequest);

--- a/src/test/java/uk/gov/pay/products/client/publicapi/PublicApiRestClientTest.java
+++ b/src/test/java/uk/gov/pay/products/client/publicapi/PublicApiRestClientTest.java
@@ -5,6 +5,7 @@ import org.apache.http.HttpStatus;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.socket.PortFactory;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.client.RestClientFactory;
 import uk.gov.pay.products.config.RestClientConfiguration;
 import uk.gov.pay.products.exception.PublicApiResponseErrorException;
@@ -45,13 +46,16 @@ public class PublicApiRestClientTest {
         String returnUrl = "http://return.url";
         String nextUrl = "http://next.url";
         String apiToken = "api-token";
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
-        JsonObject expectedPaymentRequestPayload = createPaymentRequestPayload(amount, reference, description, returnUrl);
-        JsonObject paymentResponsePayload = PublicApiStub.createPaymentResponsePayload(paymentId, amount, reference, description, returnUrl, nextUrl);
+        JsonObject expectedPaymentRequestPayload = createPaymentRequestPayload(
+                amount, reference, description, returnUrl, language.toString());
+        JsonObject paymentResponsePayload = PublicApiStub.createPaymentResponsePayload(
+                paymentId, amount, reference, description, returnUrl, nextUrl, language.toString());
 
         setupResponseToCreatePaymentRequest(apiToken, expectedPaymentRequestPayload, paymentResponsePayload);
 
-        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl);
+        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language);
         PaymentResponse actualPaymentResponse = publicApiRestClient.createPayment(apiToken, paymentRequest);
         assertThat(actualPaymentResponse, hasAllPaymentProperties(paymentResponsePayload));
     }
@@ -63,13 +67,15 @@ public class PublicApiRestClientTest {
         String description = "A Service Description";
         String returnUrl = "http://return.url";
         String apiToken = "api-token";
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
-        JsonObject expectedPaymentRequestPayload = createPaymentRequestPayload(amount, reference, description, returnUrl);
+        JsonObject expectedPaymentRequestPayload = createPaymentRequestPayload(
+                amount, reference, description, returnUrl, language.toString());
         JsonObject errorPayload = PublicApiStub.createErrorPayload();
 
         setupResponseToCreatePaymentRequest(apiToken, expectedPaymentRequestPayload, errorPayload, SC_BAD_REQUEST);
 
-        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl);
+        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language);
 
         try {
             publicApiRestClient.createPayment(apiToken, paymentRequest);
@@ -88,12 +94,14 @@ public class PublicApiRestClientTest {
         String description = "A Service Description";
         String returnUrl = "http://return.url";
         String apiToken = "invalid-token";
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
-        JsonObject expectedPaymentRequestPayload = createPaymentRequestPayload(amount, reference, description, returnUrl);
+        JsonObject expectedPaymentRequestPayload = createPaymentRequestPayload(
+                amount, reference, description, returnUrl, language.toString());
 
         setupResponseToCreatePaymentRequest(apiToken, expectedPaymentRequestPayload, HttpStatus.SC_UNAUTHORIZED);
 
-        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl);
+        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language);
         try {
             publicApiRestClient.createPayment(apiToken, paymentRequest);
             fail("Expected an PublicApiResponseErrorException to be thrown");
@@ -111,8 +119,10 @@ public class PublicApiRestClientTest {
         String returnUrl = "http://return.url";
         String nextUrl = "http://next.url";
         String apiToken = "api-token";
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
-        JsonObject paymentResponsePayload = PublicApiStub.createPaymentResponsePayload(paymentId, amount, reference, description, returnUrl, nextUrl);
+        JsonObject paymentResponsePayload = PublicApiStub.createPaymentResponsePayload(
+                paymentId, amount, reference, description, returnUrl, nextUrl, language.toString());
 
         setupResponseToGetPaymentRequest(paymentId, paymentResponsePayload);
 

--- a/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/PaymentResourceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.fixtures.ProductEntityFixture;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.entity.PaymentEntity;
@@ -41,6 +42,7 @@ public class PaymentResourceTest extends IntegrationTest {
         Product product = aProductEntity()
                 .withExternalId(randomUuid())
                 .withGatewayAccountId(0)
+                .withLanguage(SupportedLanguage.WELSH)
                 .build()
                 .toProduct();
 
@@ -55,7 +57,8 @@ public class PaymentResourceTest extends IntegrationTest {
                 referenceNumber,
                 product.getName(),
                 product.getReturnUrl(),
-                nextUrl));
+                nextUrl,
+                product.getLanguage().toString()));
 
         ValidatableResponse response = givenSetup()
                 .accept(APPLICATION_JSON)
@@ -103,6 +106,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 .withGatewayAccountId(7)
                 .withReferenceEnabled(true)
                 .withReferenceLabel("A ref label")
+                .withLanguage(SupportedLanguage.WELSH)
                 .build()
                 .toProduct();
 
@@ -118,7 +122,8 @@ public class PaymentResourceTest extends IntegrationTest {
                 referenceNumber,
                 product.getName(),
                 product.getReturnUrl(),
-                nextUrl));
+                nextUrl,
+                product.getLanguage().toString()));
 
         Map<String, String> payload = ImmutableMap.of("price", priceOverride.toString(), "reference_number", userDefinedReference);
         ValidatableResponse response = givenSetup()
@@ -152,6 +157,7 @@ public class PaymentResourceTest extends IntegrationTest {
                 .withExternalId(productExternalId)
                 .withReferenceEnabled(true)
                 .withReferenceLabel("Reference label")
+                .withLanguage(SupportedLanguage.WELSH)
                 .build();
 
         Product product = productEntity.toProduct();
@@ -176,14 +182,15 @@ public class PaymentResourceTest extends IntegrationTest {
         String govukPaymentId = "govukPaymentId";
         String nextUrl = "http://next.url";
         Long priceOverride = 501L;
-        
+
         setupResponseToCreatePaymentRequest(productEntity.getPayApiToken(), createPaymentResponsePayload(
                 govukPaymentId,
                 priceOverride,
                 userDefinedReference,
                 productEntity.getName(),
                 productEntity.getReturnUrl(),
-                nextUrl));
+                nextUrl,
+                productEntity.getLanguage().toString()));
 
         Map<String, String> payload = ImmutableMap.of("price", priceOverride.toString(), "reference_number", userDefinedReference);
         givenSetup()
@@ -200,6 +207,7 @@ public class PaymentResourceTest extends IntegrationTest {
         Product product = aProductEntity()
                 .withExternalId(randomUuid())
                 .withGatewayAccountId(0)
+                .withLanguage(SupportedLanguage.WELSH)
                 .build()
                 .toProduct();
 
@@ -208,14 +216,15 @@ public class PaymentResourceTest extends IntegrationTest {
 
         String govukPaymentId = "govukPaymentId";
         String nextUrl = "http://next.url";
-        
+
         setupResponseToCreatePaymentRequest(product.getPayApiToken(), createPaymentResponsePayload(
                 govukPaymentId,
                 priceOverride,
                 referenceNumber,
                 product.getName(),
                 product.getReturnUrl(),
-                nextUrl));
+                nextUrl,
+                product.getLanguage().toString()));
 
         Map<String, Long> payload = ImmutableMap.of("price", priceOverride);
         ValidatableResponse response = givenSetup()

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -10,6 +10,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.client.publicapi.PaymentRequest;
 import uk.gov.pay.products.client.publicapi.PaymentResponse;
 import uk.gov.pay.products.client.publicapi.PublicApiRestClient;
@@ -94,6 +95,7 @@ public class PaymentCreatorTest {
         String paymentNextUrl = "http://next.url";
         String productsUIConfirmUri = "https://products-ui/payment-complete";
         String paymentReturnUrl = format("%s/%s", productsUIConfirmUri, paymentExernalId);
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         ProductEntity productEntity = createProductEntity(
                 productId,
@@ -103,12 +105,14 @@ public class PaymentCreatorTest {
                 productReturnUrl,
                 productApiToken,
                 gatewayAccountId,
-                false);
+                false,
+                language);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 productPrice,
                 referenceNumber,
                 productName,
-                paymentReturnUrl);
+                paymentReturnUrl,
+                language);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 paymentAmount,
@@ -164,6 +168,7 @@ public class PaymentCreatorTest {
         Long paymentAmount = 50L;
         String paymentNextUrl = "http://next.url";
         String referenceNumber = createRandomReferenceNumber();
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         ProductEntity productEntity = createProductEntity(
                 productId,
@@ -173,12 +178,14 @@ public class PaymentCreatorTest {
                 "",
                 productApiToken,
                 gatewayAccountId,
-                false);
+                false,
+                language);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 productPrice,
                 referenceNumber,
                 productName,
-                productReturnUrl + "/" + paymentExternalId);
+                productReturnUrl + "/" + paymentExternalId,
+                language);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 paymentAmount,
@@ -233,6 +240,7 @@ public class PaymentCreatorTest {
         String paymentId = "payment-id";
         String paymentExternalId = "random-external-id";
         String paymentNextUrl = "http://next.url";
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         Long priceOverride = 500L;
 
@@ -244,12 +252,14 @@ public class PaymentCreatorTest {
                 "",
                 productApiToken,
                 gatewayAccountId,
-                true);
+                true,
+                language);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 priceOverride,
                 userDefinedReference,
                 productName,
-                productReturnUrl + "/" + paymentExternalId);
+                productReturnUrl + "/" + paymentExternalId,
+                language);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 priceOverride,
@@ -294,6 +304,7 @@ public class PaymentCreatorTest {
         String paymentExternalId = "random-external-id";
         String paymentNextUrl = "http://next.url";
         String referenceNumber = createRandomReferenceNumber();
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         Long priceOverride = 500L;
 
@@ -305,12 +316,14 @@ public class PaymentCreatorTest {
                 "",
                 productApiToken,
                 gatewayAccountId,
-                false);
+                false,
+                language);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 priceOverride,
                 referenceNumber,
                 productName,
-                productReturnUrl + "/" + paymentExternalId);
+                productReturnUrl + "/" + paymentExternalId,
+                language);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 priceOverride,
@@ -355,7 +368,7 @@ public class PaymentCreatorTest {
         String referenceNumber = createRandomReferenceNumber();
         String productsUIConfirmUri = "https://products-ui/payment-complete";
         String paymentReturnUrl = format("%s/%s", productsUIConfirmUri, paymentExternalId);
-
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         ProductEntity productEntity = createProductEntity(
                 productId,
@@ -365,12 +378,14 @@ public class PaymentCreatorTest {
                 productReturnUrl,
                 productApiToken,
                 gatewayAccountId,
-                false);
+                false,
+                language);
         PaymentRequest expectedPaymentRequest = createPaymentRequest(
                 productPrice,
                 referenceNumber,
                 productName,
-                paymentReturnUrl);
+                paymentReturnUrl,
+                language);
 
         when(productDao.findByExternalId(productExternalId)).thenReturn(Optional.of(productEntity));
         when(randomUuid()).thenReturn(paymentExternalId);
@@ -417,6 +432,7 @@ public class PaymentCreatorTest {
         String productName = "name";
         String productReturnUrl = "https://return.url";
         String productApiToken = "api-token";
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         Integer gatewayAccountId = 1;
 
@@ -428,7 +444,8 @@ public class PaymentCreatorTest {
                 productReturnUrl,
                 productApiToken,
                 gatewayAccountId,
-                true);
+                true,
+                language);
 
         when(productDao.findByExternalId(productExternalId)).thenReturn(Optional.of(productEntity));
 
@@ -449,6 +466,7 @@ public class PaymentCreatorTest {
         String productApiToken = "api-token";
         String paymentId = "abcd1234";
         Integer gatewayAccountId = 1;
+        SupportedLanguage language = SupportedLanguage.WELSH;
 
         ProductEntity productEntity = createProductEntity(
                 productId,
@@ -458,7 +476,8 @@ public class PaymentCreatorTest {
                 productReturnUrl,
                 productApiToken,
                 gatewayAccountId,
-                false);
+                false,
+                language);
 
         PaymentEntity paymentEntity = createPaymentEntity(
                 paymentId,
@@ -478,7 +497,15 @@ public class PaymentCreatorTest {
         verify(paymentDao, times(3)).findByGatewayAccountIdAndReferenceNumber(gatewayAccountId, randomUserFriendlyReference);
     }
 
-    private ProductEntity createProductEntity(int id, long price, String externalId, String name, String returnUrl, String apiToken, Integer gatewayAccountId, Boolean referenceEnabled) {
+    private ProductEntity createProductEntity(int id,
+                                              long price,
+                                              String externalId,
+                                              String name,
+                                              String returnUrl,
+                                              String apiToken,
+                                              Integer gatewayAccountId,
+                                              Boolean referenceEnabled,
+                                              SupportedLanguage language) {
         ProductEntity productEntity = new ProductEntity();
         productEntity.setId(id);
         productEntity.setPrice(price);
@@ -488,6 +515,7 @@ public class PaymentCreatorTest {
         productEntity.setPayApiToken(apiToken);
         productEntity.setReferenceEnabled(referenceEnabled);
         productEntity.setGatewayAccountId(gatewayAccountId);
+        productEntity.setLanguage(language);
 
         return productEntity;
     }
@@ -504,8 +532,12 @@ public class PaymentCreatorTest {
         return paymentResponse;
     }
 
-    private PaymentRequest createPaymentRequest(long price, String externalId, String description, String returnUrl) {
-        return new PaymentRequest(price, externalId, description, returnUrl);
+    private PaymentRequest createPaymentRequest(long price,
+                                                String externalId,
+                                                String description,
+                                                String returnUrl,
+                                                SupportedLanguage language) {
+        return new PaymentRequest(price, externalId, description, returnUrl, language);
     }
 
     private PaymentEntity createPaymentEntity(String paymentId, String nextUrl, ProductEntity productEntity, PaymentStatus status, Long amount) {

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
@@ -21,16 +21,23 @@ public class PublicApiStub {
     private static final String PAYMENTS_PATH = "/v1/payments";
     private static final String PAYMENT_PATH = PAYMENTS_PATH + "/%s";
     
-    public static JsonObject createPaymentRequestPayload(long amount, String reference, String description, String returnUrl) {
+    public static JsonObject createPaymentRequestPayload(long amount, String reference, String description, String returnUrl, String language) {
         return Json.createObjectBuilder()
                 .add("amount", amount)
                 .add("reference", reference)
                 .add("description", description)
                 .add("return_url", returnUrl)
+                .add("language", language)
                 .build();
     }
 
-    public static JsonObject createPaymentResponsePayload(String paymentId, long amount, String reference, String description, String returnUrl, String nextUrl) {
+    public static JsonObject createPaymentResponsePayload(String paymentId,
+                                                          long amount,
+                                                          String reference,
+                                                          String description,
+                                                          String returnUrl,
+                                                          String nextUrl,
+                                                          String language) {
         return Json.createObjectBuilder()
                 .add("amount", amount)
                 .add("state",
@@ -41,6 +48,7 @@ public class PublicApiStub {
                                 .add("code", "P010"))
                 .add("description", description)
                 .add("reference", reference)
+                .add("language", language)
                 .add("email", "your email")
                 .add("payment_id", paymentId)
                 .add("payment_provider", "worldpay")


### PR DESCRIPTION
Provide the language of the product when calling Public API to create the payment and expect it in the Public API response.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
