### PR TITLE
PP-4864: Stop deduplicating certs when adding to truststore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM govukpay/openjdk:alpine-3.9-jre-base-8.201.08
 
 RUN apk --no-cache upgrade
 
-# openssl is only here temporarily whilst docker-startup.sh needs it
-RUN apk --no-cache add bash openssl
+RUN apk --no-cache add bash
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -6,17 +6,12 @@ RUN_APP=${RUN_APP:-true}
 
 if [ -n "${CERTS_PATH:-}" ]; then
   i=0
-  truststore=/etc/ssl/certs/java/cacerts
+  truststore=$JAVA_HOME/lib/security/cacerts
   truststore_pass=changeit
-  existing_fingerprints=$(keytool -list -keystore "$truststore" -storepass "$truststore_pass"| sed -ne 's/^Certificate fingerprint (SHA1): //p')
   for cert in "$CERTS_PATH"/*; do
     [ -f "$cert" ] || continue
-    if grep -qFx "$(openssl x509 -in "$cert" -fingerprint -noout | sed -ne 's/^SHA1 Fingerprint=//p')" <<<"$existing_fingerprints"; then
-      echo "$cert already in truststore $truststore"
-    else
-      echo "Adding $cert to $truststore"
-      keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-    fi
+    echo "Adding $cert to $truststore"
+    keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
   done
 fi
 


### PR DESCRIPTION
We had code to avoid adding duplicate certificates to the default Java
truststore from $CERTS_PATH. This was only needed because adding a certificate
takes 0.5s and we mounted all the Ubuntu trusted CAs into the container in ECS
environments. This is no longer the case - we no longer set CERTS_PATH in ECS
environments, so we don't need this extra complexity.

Also, use $JAVA_HOME to find the default truststore instead of relying on a
hardcoded path.