### PR TITLE
PP-5017 Add provider states for selfservice pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/products/pact/ProviderContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/ProviderContractTest.java
@@ -46,18 +46,20 @@ public class ProviderContractTest {
     @State("default")
     public void noSetUp() {
     }
-    
-    @State({"a product with external id existing-id exists"})
+
+    @State({"a product with external id existing-id exists",
+            "a product with external id existing-id and gateway account id 42 exists"})
     public void aProductExists() {
         Product product = aProductEntity()
                 .withExternalId("existing-id")
+                .withGatewayAccountId(42)
                 .build()
                 .toProduct();
 
         dbHelper.addProduct(product);
     }
 
-    @State({"a product with path service-name-path/product-name-path exists"})
+    @State("a product with path service-name-path/product-name-path exists")
     public void aProductWithPathExists() {
         Product product = aProductEntity()
                 .withProductPath("service-name-path", "product-name-path")
@@ -66,7 +68,7 @@ public class ProviderContractTest {
 
         dbHelper.addProduct(product);
     }
-    
+
     @State("three products with gateway account id 42 exist")
     public void threeProductsExistForGatewayAccount() {
         dbHelper.addProduct(aProductEntity()


### PR DESCRIPTION
Just specified a gateway account on an existing state and added another state label so that selfservice pact tests can be switched on.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
