### PR TITLE
PP-5076: Document all environment variables used by products

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,28 @@ These products are integrated with GOV.UK Pay so that a user can make payments u
 
 ## Environment Variables
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `PRODUCTS_UI_URL` | - | base url of the products ui micro service |
+| Variable | Description |
+|----------|-------------|
+| `ADMIN_PORT`                  | The port number to listen for Dropwizard admin requests on. Defaults to `8081`. |
+| `BASE_URL`                    | The base URL of the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
+| `CERTS_PATH`                  | If set, add all certificates in this directory to the default Java truststore. |
+| `DB_HOST`                     | The hostname of the database server. Defaults to `products.db.pymnt.localdomain` |
+| `DB_PASSWORD`                 | The password for the `DB_USER` user. |
+| `DB_SSL_OPTION`               | To turn TLS on this value must be set as `ssl=true`. Otherwise must be empty. |
+| `DB_USER`                     | The username to log into the database as. |
+| `JAVA_HOME`                   | The location of the JRE. Set to `/opt/java/openjdk` in the `Dockerfile`. |
+| `JAVA_OPTS`                   | Commandline arguments to pass to the java runtime. Optional. |
+| `JPA_LOG_LEVEL`               | The logging level to set for JPA. Defaults to `WARNING`. |
+| `JPA_SQL_LOG_LEVEL`           | The logging level to set for JPA SQL logging. Defaults to `WARNING`. |
+| `METRICS_HOST`                | The hostname to send graphite metrics to. Defaults to `localhost`. |
+| `METRICS_PORT`                | The port number to send graphite metrics to. Defaults to `8092`. |
+| `PORT`                        | The port number to listen for requests on. Defaults to `8080`. |
+| `PRODUCTSUI_CONFIRMATION_URL` | The URL of the confirmation page endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
+| `PRODUCTSUI_PAY_URL`          | The URL of the `pay` endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
+| `PRODUCTS_FRIENDLY_BASE_URI`  | The URL of the products endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
+| `PUBLICAPI_URL`               | The URL to the [publicapi](https://github.com/alphagov/pay-publicapi) microservice |
+| `RUN_APP`                     | Set to `true` to run the application. Defaults to `true`. |
+| `RUN_MIGRATION`               | Set to `true` to run a database migration. Defaults to `false`. |
 
 ## API Specification
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,10 +1,10 @@
 server:
   applicationConnectors:
     - type: http
-      port: ${PORT:-0}
+      port: ${PORT:-8080}
   adminConnectors:
     - type: http
-      port: ${ADMIN_PORT:-0}
+      port: ${ADMIN_PORT:-8081}
 
 logging:
   level: INFO


### PR DESCRIPTION
Update README.md to describe all environment variables used by the `products`
microservice as per `docker-startup.sh` and the Dropwizard configuration file.

Also set sensible defaults for `PORT` and `ADMIN_PORT` in the Dropwizard config
file, to match the settings in the `Dockerfile`.
