### PR TITLE
PP-4493 Expect Reference information in update product request

### DIFF
--- a/src/main/java/uk/gov/pay/products/service/ProductCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductCreator.java
@@ -40,6 +40,10 @@ public class ProductCreator {
                     productEntity.setName(product.getName());
                     productEntity.setDescription(product.getDescription());
                     productEntity.setPrice(product.getPrice());
+                    productEntity.setReferenceEnabled(product.getReferenceEnabled());
+                    productEntity.setReferenceLabel(product.getReferenceLabel());
+                    productEntity.setReferenceHint(product.getReferenceHint());
+
                     return linksDecorator.decorate(productEntity.toProduct());
                 });
     }


### PR DESCRIPTION
- Selfservice now sends the reference fields when making a request to update a product. Use this when updating the product

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
