### PR TITLE
Separate integration tests from unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           long stepBuildTime = System.currentTimeMillis()
           sh 'docker pull govukpay/postgres:9.4.4'
           sh 'mvn -version'
-          sh 'mvn clean package'
+          sh 'mvn clean verify'
           runProviderContractTests()
           postSuccessfulMetrics("products.maven-build", stepBuildTime)
         }

--- a/build-local.sh
+++ b/build-local.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")"
 
-mvn -DskipTests clean package
+mvn -DskipITs clean verify
 docker build -t govukpay/products:local .

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,21 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>failsafe-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/src/test/java/uk/gov/pay/products/persistence/dao/PaymentDaoIT.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/PaymentDaoIT.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
-public class PaymentDaoTest extends DaoTestBase {
+public class PaymentDaoIT extends DaoTestBase {
 
     private PaymentDao paymentDao;
     private ProductEntity productEntity;

--- a/src/test/java/uk/gov/pay/products/persistence/dao/ProductDaoIT.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/ProductDaoIT.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
-public class ProductDaoTest extends DaoTestBase {
+public class ProductDaoIT extends DaoTestBase {
 
     private ProductDao productDao;
 

--- a/src/test/java/uk/gov/pay/products/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/PaymentResourceIT.java
@@ -30,7 +30,7 @@ import static uk.gov.pay.products.stubs.publicapi.PublicApiStub.setupResponseToC
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
-public class PaymentResourceTest extends IntegrationTest {
+public class PaymentResourceIT extends IntegrationTest {
 
     private final String paymentsUrl = "https://products.url/v1/api/payments/";
     private final String nextUrl = "www.gov.uk/pay";

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
@@ -26,7 +26,7 @@ import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
-public class ProductResourceTest extends IntegrationTest {
+public class ProductResourceIT extends IntegrationTest {
 
     private static final String PAY_API_TOKEN = "pay_api_token";
     private static final String NAME = "name";


### PR DESCRIPTION
Integration tests are slow. They involve starting a PostgreSQL container and
instantiating Dropwizard.

Split them from the unit tests and run the unit tests with the surefire plugin
instead.

Rename integration tests to match the default include/exclude rules for the
surefire and failsafe maven plugins. By default, the failsafe plugin will
include any tests matching IT*.java, *IT.java and *ITCase.java. This was not
the naming scheme our integration tests had, so fix that.

Since unit tests are so quick, we no longer need to skip them when running
local builds.

maven's 'package' target doesn't include running integration tests, so switch
to using the 'verify' target during CI builds, which is what we should've been
doing anyway.