### PR TITLE
RED-116: Use tini in docker to run java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# adoptopenjdk/openjdk11:jre-11.0.3_7-alpine
 FROM adoptopenjdk/openjdk11@sha256:eaa182283f19d3f0ee0c6217d29e299bb4056d379244ce957e30dcdc9e278e1e
 
 RUN ["apk", "--no-cache", "upgrade"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo networkaddress.cache.ttl=$DNS_TTL >> "$JAVA_HOME/conf/security/java.sec
 RUN wget -qO - https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem       | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-ca-2015-root \
  && wget -qO - https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | keytool -importcert -noprompt -cacerts -storepass changeit -alias rds-combined-ca-bundle
 
-RUN ["apk", "add", "--no-cache", "bash"]
+RUN ["apk", "add", "--no-cache", "bash", "tini"]
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081
@@ -27,4 +27,6 @@ ADD docker-startup.sh /app/docker-startup.sh
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 
-CMD bash ./docker-startup.sh
+ENTRYPOINT ["tini", "-e", "143", "--"]
+
+CMD ["bash", "./docker-startup.sh"]

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -21,5 +21,5 @@ if [ "$RUN_MIGRATION" == "true" ]; then
 fi
 
 if [ "$RUN_APP" == "true" ]; then
-  java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+  exec java $JAVA_OPTS -jar *-allinone.jar server *.yaml
 fi


### PR DESCRIPTION
By having bash as PID 1, we have a problem. Signals sent to the container (e.g.
SIGTERM to shut it down) will not reach Java - bash will not pass them on. This
means that shutting the container down is done uncleanly. Once the SIGTERM is
ignored, the container orchestrator will then send a SIGKILL and forcibly exit
the process.

We could make java PID 1 instead but this creates further problems - If Java
creates any child processes and those processes (or any of their children) die,
Java will be the parent of them and will not know to waitpid() on them, so they
will remain zombies forever. This is not a problem for connector as no such child
processes should be created, but it's still not really correct.

Also, when Java receives SIGTERM, it exits with an exit code of 15, even if
everything was shut down correctly. This will be mapped to exit code 143 by
Docker. tini can map this to zero to indicate that shutdown was clean.

tini solves all of these problems - it will correctly reparent orphaned child
processes and can remap the strange exit code of Java to something more
palatable.

In order to stop bash masking signals from Java, run java with 'exec' so that
no subprocess is spawned.

Also, use the array-style form of `CMD` to avoid wrapping bash in another
shell.