### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
         }
       }
       steps {
-        runProductsE2E("products")
+        runAppE2E("products", "products")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere
