### PR TITLE
Make secure return URLs optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ These products are integrated with GOV.UK Pay so that a user can make payments u
 | `PUBLICAPI_URL`               | The URL to the [publicapi](https://github.com/alphagov/pay-publicapi) microservice |
 | `RUN_APP`                     | Set to `true` to run the application. Defaults to `true`. |
 | `RUN_MIGRATION`               | Set to `true` to run a database migration. Defaults to `false`. |
+| `SECURE_RETURN_URLS`          | Set to `false` to allow non-HTTPS URLs for the `return_url` field of a product. Defaults to `true`. |
 
 ## API Specification
 

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -37,6 +37,9 @@ public class ProductsConfiguration extends Configuration {
     @NotNull
     private String friendlyBaseUri;
 
+    @NotNull
+    private boolean returnUrlMustBeSecure = true;
+
     public String getVcapServices() {
         return System.getenv("VCAP_SERVICES");
     }
@@ -84,4 +87,8 @@ public class ProductsConfiguration extends Configuration {
     }
 
     public String getFriendlyBaseUri() { return friendlyBaseUri; }
+
+    public boolean getReturnUrlMustBeSecure() {
+        return returnUrlMustBeSecure;
+    }
 }

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -3,6 +3,7 @@ package uk.gov.pay.products.validations;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.products.config.ProductsConfiguration;
 import uk.gov.pay.products.util.Errors;
 import uk.gov.pay.products.util.ProductType;
 
@@ -25,10 +26,12 @@ import static uk.gov.pay.products.util.ProductType.ADHOC;
 
 public class ProductRequestValidator {
     private final RequestValidations requestValidations;
+    private final boolean returnUrlMustBeSecure;
 
     @Inject
-    public ProductRequestValidator(RequestValidations requestValidations) {
+    public ProductRequestValidator(RequestValidations requestValidations, ProductsConfiguration configuration) {
         this.requestValidations = requestValidations;
+        this.returnUrlMustBeSecure = configuration.getReturnUrlMustBeSecure();
     }
 
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
@@ -40,7 +43,9 @@ public class ProductRequestValidator {
                 FIELD_TYPE);
 
         if (errors.isEmpty() && payload.get(FIELD_RETURN_URL) != null) {
-            errors = requestValidations.checkIsUrl(payload, FIELD_RETURN_URL);
+            errors = returnUrlMustBeSecure
+                    ? requestValidations.checkIsHttpsUrl(payload, FIELD_RETURN_URL)
+                    : requestValidations.checkIsUrl(payload, FIELD_RETURN_URL);
         }
 
         if (errors.isEmpty() && payload.get(FIELD_PRICE) != null) {

--- a/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
@@ -29,7 +29,11 @@ public class RequestValidations {
     }
     
     Optional<List<String>> checkIsUrl(JsonNode payload, String... fieldNames) {
-        return applyCheck(payload, isNotUrl(), fieldNames, "Field [%s] must be a https url");
+        return applyCheck(payload, isNotUrl(), fieldNames, "Field [%s] must be a valid URL");
+    }
+
+    Optional<List<String>> checkIsHttpsUrl(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotHttpsUrl(), fieldNames, "Field [%s] must be a https URL");
     }
 
     Optional<List<String>> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
@@ -96,16 +100,26 @@ public class RequestValidations {
 
     private static Function<JsonNode, Boolean> isNotUrl() {
         return jsonNode -> {
-            if (jsonNode == null || isBlank(jsonNode.asText()) || !jsonNode.asText().startsWith("https")) {
-                return true;
-            }
-
             try {
-                new URL(jsonNode.asText());
-            } catch (MalformedURLException e) {
-                return true;
+                if (jsonNode != null) {
+                    new URL(jsonNode.asText());
+                    return false;
+                }
+            } catch (MalformedURLException ignored) {
             }
-            return false;
+            return true;
+        };
+    }
+
+    private static Function<JsonNode, Boolean> isNotHttpsUrl() {
+        return jsonNode -> {
+            try {
+                if (jsonNode != null) {
+                    return !"https".equals(new URL(jsonNode.asText()).getProtocol());
+                }
+            } catch (MalformedURLException ignored) {
+            }
+            return true;
         };
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -66,3 +66,4 @@ publicApiUrl: ${PUBLICAPI_URL}
 productsUiPayUrl: ${PRODUCTSUI_PAY_URL}
 productsUiConfirmUrl: ${PRODUCTSUI_CONFIRMATION_URL}
 friendlyBaseUri: ${PRODUCTS_FRIENDLY_BASE_URI}
+returnUrlMustBeSecure: ${SECURE_RETURN_URLS:-true}

--- a/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.products.util.Errors;
 
+import java.net.URL;
 import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;
@@ -25,7 +26,7 @@ public class PaymentRequestValidatorTest {
     }
 
     @Test
-    public void shouldSuccess_onCreatePayment_ifJsonPayloadIsNull() {
+    public void shouldSuccess_onCreatePayment_ifJsonPayloadIsNull() throws Exception {
         Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(null);
         assertFalse(errors.isPresent());
     }

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+import uk.gov.pay.products.config.ProductsConfiguration;
 import uk.gov.pay.products.util.Errors;
 import uk.gov.pay.products.util.ProductType;
 
@@ -32,7 +33,7 @@ public class ProductRequestValidatorTest {
     private static final String FIELD_REFERENCE_HINT = "reference_hint";
     private static final String FIELD_LANGUAGE = "language";
 
-    private static final ProductRequestValidator productRequestValidator = new ProductRequestValidator(new RequestValidations());
+    private static final ProductRequestValidator productRequestValidator = new ProductRequestValidator(new RequestValidations(), new ProductsConfiguration());
 
     @Test
     public void shouldPass_whenAllFieldsPresent() {
@@ -273,7 +274,7 @@ public class ProductRequestValidatorTest {
 
 
         assertThat(errors.isPresent(), is(true));
-        assertThat(errors.get().getErrors().toString(), is("[Field [return_url] must be a https url]"));
+        assertThat(errors.get().getErrors().toString(), is("[Field [return_url] must be a https URL]"));
     }
 
     @Test
@@ -296,7 +297,7 @@ public class ProductRequestValidatorTest {
 
 
         assertThat(errors.isPresent(), is(true));
-        assertThat(errors.get().getErrors().toString(), is("[Field [return_url] must be a https url]"));
+        assertThat(errors.get().getErrors().toString(), is("[Field [return_url] must be a https URL]"));
     }
 
     @Test

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -69,3 +69,4 @@ publicApiUrl: https://publicapi.url
 productsUiPayUrl: https://products-ui.url/pay
 productsUiConfirmUrl: https://products.url/confirm
 friendlyBaseUri: https://products-ui.url/products
+returnUrlMustBeSecure: true


### PR DESCRIPTION
Add a configuration parameter and environment variable (SECURE_RETURN_URLS) to
permit the 'return_url' of a product to be non-https
