### PR TITLE
Remove parameter to tagDeployment() in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
             branch 'master'
           }
           steps {
-            tagDeployment("products")
+            tagDeployment()
           }
         }
         stage('Trigger Deploy Notification') {


### PR DESCRIPTION
Since https://github.com/alphagov/pay-jenkins-library/pull/117, tagDeployment()
needs no parameters.