### PR TITLE
Define the graphite port number as an integer in configuration

### DIFF
--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -90,7 +90,7 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
                 .build()
                 .scheduleAtFixedRate(metricsService::updateMetricData, 0, GRAPHITE_SENDING_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
 
-        GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), Integer.valueOf(configuration.getGraphitePort()));
+        GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), configuration.getGraphitePort());
         GraphiteReporter.forRegistry(environment.metrics())
                 .prefixedWith(SERVICE_METRICS_NODE)
                 .build(graphiteUDP)

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -12,7 +12,7 @@ public class ProductsConfiguration extends Configuration {
     @NotNull
     private String graphiteHost;
     @NotNull
-    private String graphitePort;
+    private Integer graphitePort;
 
     @Valid
     @NotNull
@@ -53,7 +53,7 @@ public class ProductsConfiguration extends Configuration {
         return graphiteHost;
     }
 
-    public String getGraphitePort() {
+    public Integer getGraphitePort() {
         return graphitePort;
     }
 

--- a/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.products.util.Errors;
 
-import java.net.URL;
 import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;


### PR DESCRIPTION
## WHAT YOU DID
Remove an unused import from a test

Define the graphite port number as an integer and let the Dropwizard configuration parser handle the parsing of it.