### PR TITLE
PP-5670: Specify the consumer when running contract test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <powermock.version>2.0.2</powermock.version>
         <wiremock.version>2.25.0</wiremock.version>
         <jackson.version>2.9.9</jackson.version>
-        <pay-java-commons.version>1.0.20191001125636</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191002153026</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
     </properties>
 

--- a/src/test/java/uk/gov/pay/products/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/ContractTest.java
@@ -1,28 +1,19 @@
 package uk.gov.pay.products.pact;
 
-import au.com.dius.pact.provider.junit.PactRunner;
-import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
-import au.com.dius.pact.provider.junit.loader.PactBroker;
-import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.runner.RunWith;
 import uk.gov.pay.products.infra.DropwizardAppWithPostgresRule;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.utils.DatabaseTestHelper;
 
 import static uk.gov.pay.products.fixtures.ProductEntityFixture.aProductEntity;
 
-@RunWith(PactRunner.class)
-@Provider("products")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
-        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
-public class ProviderContractTest {
+public abstract class ContractTest {
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
 

--- a/src/test/java/uk/gov/pay/products/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/products/pact/ContractTestSuite.java
@@ -1,11 +1,20 @@
 package uk.gov.pay.products.pact;
 
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.runners.AllTests;
+import uk.gov.pay.commons.testing.pact.provider.CreateTestSuite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        ProviderContractTest.class
-})
+import java.util.Map;
+
+@RunWith(AllTests.class)
 public class ContractTestSuite {
+
+    public static TestSuite suite() {
+        Map<String, JUnit4TestAdapter> map = Map.of(
+                "products-ui", new JUnit4TestAdapter(ProductsUIContractTest.class),
+                "selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
+        return CreateTestSuite.create(map);
+    }
 }

--- a/src/test/java/uk/gov/pay/products/pact/ProductsUIContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/ProductsUIContractTest.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.products.pact;
+
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("products")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"products-ui"})
+public class ProductsUIContractTest extends ContractTest {
+}

--- a/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.products.pact;
+
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("products")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"selfservice"})
+public class SelfServiceContractTest extends ContractTest {
+}


### PR DESCRIPTION
Currently when a consumer build is kicked off, the provider contract test will
run in its entirety. For example, in a selfservice build, the products provider
contract tests will run as well. However, what is run is:

products-ui->products
selfservice->products

We really only want to run selfservice->products in this case.

This commit will allow a dynamic creation of the test suite to run based on a
CONSUMER system property. This will mean shorter run times when a provider
contract test is run as part of a specific consumer build.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
