### PR TITLE
PP-5725 Add Sentry config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,11 @@
             <artifactId>model</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>dropwizard-sentry</artifactId>
+            <version>1.3.9-1</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -14,6 +14,10 @@ logging:
       timeZone: UTC
       target: stdout
       logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+    - type: sentry
+      threshold: ERROR
+      dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
+      environment: ${ENVIRONMENT}
 
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}


### PR DESCRIPTION
Add Sentry logging appender so that logs at ERROR level and uncaught
exceptions are reported to Sentry. Same implementations as per
alphagov/pay-direct-debit-connector#745

There is a default value for the dsn so that the app will start if the
SENTRY_DSN env variable has not been set.