### PR TITLE
Remove Postgres container pre-pull from build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
       steps {
         script {
           long stepBuildTime = System.currentTimeMillis()
-          sh 'docker pull govukpay/postgres:9.4.4'
+          sh 'docker pull govukpay/postgres:9.6.6'
           sh 'mvn -version'
           sh 'mvn clean verify'
           runProviderContractTests()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,6 @@ pipeline {
       steps {
         script {
           long stepBuildTime = System.currentTimeMillis()
-          sh 'docker pull govukpay/postgres:9.6.6'
           sh 'mvn -version'
           sh 'mvn clean verify'
           runProviderContractTests()


### PR DESCRIPTION
## WHAT YOU DID
The Jenkins pipeline pre-pulls a Postgres 9.4.4 container used by the test suite. This isn't actually used by the test suite. 
The container used by the tests is specified in the pay-java-commons library. 
This configures DB tests start and run Postgres 9.6.6 or which ever version was specified in a given version of `pay-java-commons`

See: https://github.com/alphagov/pay-java-commons/blob/master/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java#L62

## How to test

The 9.4.4 container is no longer on docker-hub causing the existing build pipeline to fail.
The test suite should now pull the correct Postgres version.
