### PR TITLE
PP-6020 Send source flag with create payment request

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/Internal.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/Internal.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.products.client.publicapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.commons.model.Source;
+
+public class Internal {
+
+    @JsonProperty("source")
+    private Source source;
+
+    public Internal(Source source) {
+        this.source = source;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/client/publicapi/PaymentRequest.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PaymentRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -15,18 +16,21 @@ public class PaymentRequest {
     private String description;
     private String returnUrl;
     private SupportedLanguage language;
+    private Internal internal;
 
     public PaymentRequest(
             @JsonProperty("amount") long amount,
             @JsonProperty("reference") String reference,
             @JsonProperty("description") String description,
             @JsonProperty("return_url") String returnUrl,
-            @JsonProperty("language") @JsonSerialize(using = ToStringSerializer.class) SupportedLanguage language) {
+            @JsonProperty("language") @JsonSerialize(using = ToStringSerializer.class) SupportedLanguage language,
+            Source source) {
         this.amount = amount;
         this.reference = reference;
         this.description = description;
         this.returnUrl = returnUrl;
         this.language = language;
+        this.internal = new Internal(source);
     }
 
     public long getAmount() {
@@ -69,6 +73,10 @@ public class PaymentRequest {
         this.language = language;
     }
 
+    public Internal getInternal() {
+        return internal;
+    }
+
     @Override
     public String toString() {
         return "PaymentRequest{" +
@@ -77,6 +85,7 @@ public class PaymentRequest {
                 ", description='" + description + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", language='" + language.toString() + '\'' +
+                ", source='" + internal.getSource() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUserFriendlyReference;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
@@ -117,7 +118,8 @@ public class PaymentCreator {
                     paymentEntity.getReferenceNumber(),
                     productEntity.getName(),
                     returnUrl,
-                    productEntity.getLanguage());
+                    productEntity.getLanguage(),
+                    CARD_PAYMENT_LINK);
 
             try {
                 PaymentResponse paymentResponse = publicApiRestClient.createPayment(productEntity.getPayApiToken(), paymentRequest);

--- a/src/test/java/uk/gov/pay/products/client/publicapi/PublicApiRestClientTest.java
+++ b/src/test/java/uk/gov/pay/products/client/publicapi/PublicApiRestClientTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
 import static uk.gov.pay.products.matchers.PaymentResponseMatcher.hasAllPaymentProperties;
 import static uk.gov.pay.products.stubs.publicapi.PublicApiStub.createPaymentRequestPayload;
 import static uk.gov.pay.products.stubs.publicapi.PublicApiStub.setupResponseToCreatePaymentRequest;
@@ -55,8 +56,9 @@ public class PublicApiRestClientTest {
 
         setupResponseToCreatePaymentRequest(apiToken, expectedPaymentRequestPayload, paymentResponsePayload);
 
-        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language);
+        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language, CARD_PAYMENT_LINK);
         PaymentResponse actualPaymentResponse = publicApiRestClient.createPayment(apiToken, paymentRequest);
+        
         assertThat(actualPaymentResponse, hasAllPaymentProperties(paymentResponsePayload));
     }
 
@@ -75,7 +77,7 @@ public class PublicApiRestClientTest {
 
         setupResponseToCreatePaymentRequest(apiToken, expectedPaymentRequestPayload, errorPayload, SC_BAD_REQUEST);
 
-        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language);
+        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language, CARD_PAYMENT_LINK);
 
         try {
             publicApiRestClient.createPayment(apiToken, paymentRequest);
@@ -101,7 +103,7 @@ public class PublicApiRestClientTest {
 
         setupResponseToCreatePaymentRequest(apiToken, expectedPaymentRequestPayload, HttpStatus.SC_UNAUTHORIZED);
 
-        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language);
+        PaymentRequest paymentRequest = new PaymentRequest(amount, reference, description, returnUrl, language, CARD_PAYMENT_LINK);
         try {
             publicApiRestClient.createPayment(apiToken, paymentRequest);
             fail("Expected an PublicApiResponseErrorException to be thrown");

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -10,6 +10,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.products.client.publicapi.PaymentRequest;
 import uk.gov.pay.products.client.publicapi.PaymentResponse;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
 import static uk.gov.pay.products.util.PaymentStatus.ERROR;
 import static uk.gov.pay.products.util.PaymentStatus.SUBMITTED;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUserFriendlyReference;
@@ -112,7 +115,8 @@ public class PaymentCreatorTest {
                 referenceNumber,
                 productName,
                 paymentReturnUrl,
-                language);
+                language,
+                CARD_PAYMENT_LINK);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 paymentAmount,
@@ -185,7 +189,8 @@ public class PaymentCreatorTest {
                 referenceNumber,
                 productName,
                 productReturnUrl + "/" + paymentExternalId,
-                language);
+                language,
+                CARD_PAYMENT_LINK);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 paymentAmount,
@@ -259,7 +264,8 @@ public class PaymentCreatorTest {
                 userDefinedReference,
                 productName,
                 productReturnUrl + "/" + paymentExternalId,
-                language);
+                language,
+                CARD_PAYMENT_LINK);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 priceOverride,
@@ -323,7 +329,8 @@ public class PaymentCreatorTest {
                 referenceNumber,
                 productName,
                 productReturnUrl + "/" + paymentExternalId,
-                language);
+                language,
+                CARD_PAYMENT_LINK);
         PaymentResponse paymentResponse = createPaymentResponse(
                 paymentId,
                 priceOverride,
@@ -385,7 +392,8 @@ public class PaymentCreatorTest {
                 referenceNumber,
                 productName,
                 paymentReturnUrl,
-                language);
+                language,
+                CARD_PAYMENT_LINK);
 
         when(productDao.findByExternalId(productExternalId)).thenReturn(Optional.of(productEntity));
         when(randomUuid()).thenReturn(paymentExternalId);
@@ -536,8 +544,9 @@ public class PaymentCreatorTest {
                                                 String externalId,
                                                 String description,
                                                 String returnUrl,
-                                                SupportedLanguage language) {
-        return new PaymentRequest(price, externalId, description, returnUrl, language);
+                                                SupportedLanguage language,
+                                                Source source) {
+        return new PaymentRequest(price, externalId, description, returnUrl, language, source);
     }
 
     private PaymentEntity createPaymentEntity(String paymentId, String nextUrl, ProductEntity productEntity, PaymentStatus status, Long amount) {

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
@@ -28,6 +28,7 @@ public class PublicApiStub {
                 .add("description", description)
                 .add("return_url", returnUrl)
                 .add("language", language)
+                .add("internal", Json.createObjectBuilder().add("source","CARD_PAYMENT_LINK"))
                 .build();
     }
 


### PR DESCRIPTION
## WHAT YOU DID

- Public API accepts new object `internal` (https://github.com/alphagov/pay-publicapi/pull/829 ) on create payment endpoint payload. Added `source` flag with value `CARD_PAYMENT_LINK` to create payment payload
- Updated relevant tests
