### PR TITLE
PP-6149 Add ProductMetadata Entity and Dao

### DIFF
--- a/src/main/java/uk/gov/pay/products/persistence/dao/ProductMetadataDao.java
+++ b/src/main/java/uk/gov/pay/products/persistence/dao/ProductMetadataDao.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.products.persistence.dao;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import uk.gov.pay.products.persistence.entity.ProductMetadataEntity;
+
+import javax.persistence.EntityManager;
+
+public class ProductMetadataDao extends JpaDao<ProductMetadataEntity> {
+
+    @Inject
+    ProductMetadataDao(Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+}

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductMetadataEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductMetadataEntity.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.products.persistence.entity;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "products_metadata")
+public class ProductMetadataEntity extends AbstractEntity {
+
+    @ManyToOne(cascade = CascadeType.MERGE)
+    @JoinColumn(name = "product_id", updatable = false)
+    private ProductEntity productId;
+
+    @Column(name = "metadata_key")
+    private String metadataKey;
+
+    @Column(name = "metadata_value")
+    private String metadataValue;
+
+    public ProductMetadataEntity() {
+        //for jpa
+    }
+
+    public ProductEntity getProductId() {
+        return productId;
+    }
+
+    public String getMetadataKey() {
+        return metadataKey;
+    }
+
+    public String getMetadataValue() {
+        return metadataValue;
+    }
+
+    public void setProductId(ProductEntity productId) {
+        this.productId = productId;
+    }
+
+    public void setMetadataKey(String metadataKey) {
+        this.metadataKey = metadataKey;
+    }
+
+    public void setMetadataValue(String metadataValue) {
+        this.metadataValue = metadataValue;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductMetadataEntity{" +
+                "productId=" + productId +
+                ", metadataKey='" + metadataKey + '\'' +
+                ", metadataValue='" + metadataValue + '\'' +
+                '}';
+    }
+}

--- a/src/test/java/uk/gov/pay/products/fixtures/ProductMetadataEntityFixture.java
+++ b/src/test/java/uk/gov/pay/products/fixtures/ProductMetadataEntityFixture.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.products.fixtures;
+
+import org.apache.commons.lang3.RandomUtils;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+import uk.gov.pay.products.persistence.entity.ProductMetadataEntity;
+
+public class ProductMetadataEntityFixture {
+    
+    private Integer id = RandomUtils.nextInt();
+    private ProductEntity productEntity;
+    private String metadataKey = "key";
+    private String metadataValue = "value";
+
+    private ProductMetadataEntityFixture() {
+    }
+    
+    public ProductMetadataEntity build() {
+        ProductMetadataEntity productMetadataEntity = new ProductMetadataEntity();
+        productMetadataEntity.setId(this.id);
+        productMetadataEntity.setProductId(this.productEntity);
+        productMetadataEntity.setMetadataKey(this.metadataKey);
+        productMetadataEntity.setMetadataValue(this.metadataValue);
+        return productMetadataEntity;
+    }
+
+    public static ProductMetadataEntityFixture aProductMetadataEntity() {
+        return new ProductMetadataEntityFixture();
+    }
+
+    public ProductMetadataEntityFixture withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public ProductMetadataEntityFixture withProductEntity(ProductEntity productEntity) {
+        this.productEntity = productEntity;
+        return this;
+    }
+
+    public ProductMetadataEntityFixture withMetadataKey(String metadataKey) {
+        this.metadataKey = metadataKey;
+        return this;
+    }
+
+    public ProductMetadataEntityFixture withMetadataValue(String metadataValue) {
+        this.metadataValue = metadataValue;
+        return this;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/products/persistence/dao/ProductMetadataDaoIT.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/ProductMetadataDaoIT.java
@@ -1,0 +1,51 @@
+package uk.gov.pay.products.persistence.dao;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.hamcrest.MatcherAssert;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.products.fixtures.ProductEntityFixture;
+import uk.gov.pay.products.fixtures.ProductMetadataEntityFixture;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+import uk.gov.pay.products.persistence.entity.ProductMetadataEntity;
+
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
+
+public class ProductMetadataDaoIT extends DaoTestBase {
+    private ProductMetadataDao productMetadataDao;  
+    private ProductMetadataEntity productMetadataEntity;
+    private ProductDao productDao;
+    private ProductEntity productEntity;
+
+    String productExternalId = randomUuid();
+    private Integer id = RandomUtils.nextInt();
+
+    @Before
+    public void before() {
+        productDao = env.getInstance(ProductDao.class);
+        productMetadataDao = env.getInstance(ProductMetadataDao.class);
+        productEntity = ProductEntityFixture.aProductEntity()
+                .withExternalId(productExternalId)
+                .build();
+        productDao.persist(productEntity);
+        productMetadataEntity = ProductMetadataEntityFixture.aProductMetadataEntity()
+                .withProductEntity(productEntity)
+                .withMetadataKey("a key")
+                .withMetadataValue("a value")
+                .build();
+        productMetadataDao.persist(productMetadataEntity);
+        id = productMetadataEntity.getId();
+    }
+
+    @Test
+    public void productMetadataDaoShouldReturnEntity_whenIdExists() {
+        ProductMetadataEntity productMetadataEntityReturned = productMetadataDao.entityManager
+                .get()
+                .find(ProductMetadataEntity.class, id);
+        MatcherAssert.assertThat(productMetadataEntityReturned.getMetadataKey(), is("a key"));
+        MatcherAssert.assertThat(productMetadataEntityReturned.getMetadataValue(), is("a value"));
+        MatcherAssert.assertThat(productMetadataEntityReturned.getId(), is(id));
+        MatcherAssert.assertThat(productMetadataEntityReturned.getProductId().getExternalId(), is(productExternalId));
+    }
+}


### PR DESCRIPTION
- Adds `ProductMetadataEntity` and `ProductMetadataDao` to enable
programmatic access of the `products_metadata` table in the products
database.