### PR TITLE
PP-6149 Add Products Metadata Version Column

### DIFF
--- a/src/main/resources/migrations/00034_add_column_version_to_products_metadata.sql
+++ b/src/main/resources/migrations/00034_add_column_version_to_products_metadata.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_amount_on_payments
+ALTER TABLE products_metadata ADD COLUMN version INTEGER DEFAULT 0 NOT NULL;
+
+--rollback alter table products_metadata drop column version;


### PR DESCRIPTION
- I forgot to add the standard version column to `products_metadata`,
this adds it where it is missing.
