### PR TITLE
PP-6149 add product metadata validation

### DIFF
--- a/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.products.validations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import uk.gov.pay.products.model.ProductMetadata;
+import uk.gov.pay.products.util.Errors;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.function.Predicate.isEqual;
+
+public class ProductsMetadataRequestValidator {
+
+    private static final int MAX_NUMBER_OF_METADATA_ALLOWED = 10;
+    private static final int MAX_KEY_FIELD_LENGTH = 30;
+    private static final int MAX_VALUE_FIELD_LENGTH = 50;
+    private static final String MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG = format("Maximum number of allowed metadata [ %s ] exceeded", MAX_NUMBER_OF_METADATA_ALLOWED);
+
+    @Inject
+    public ProductsMetadataRequestValidator() {
+    }
+
+    public Optional<Errors> validateCreateRequest(JsonNode payload, List<ProductMetadata> existingMetadataList) {
+        if (existingMetadataList.size() >= MAX_NUMBER_OF_METADATA_ALLOWED) {
+            return Optional.of(Errors.from(MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG));
+        }
+        if(payload.isEmpty()) {
+            return Optional.of(Errors.from("Empty payload is not allowed"));
+        }
+        if (payload.size() > 1) {
+            return Optional.of(Errors.from("Only one key-value pair is allowed"));
+        }
+
+        String key = payload.fieldNames().next();
+
+        if (existingMetadataList
+                .stream()
+                .map(ProductMetadata::getKey)
+                .map(String::toLowerCase)
+                .anyMatch(isEqual(key.toLowerCase()))) {
+            return Optional.of(Errors.from(format("Key [ %s ] already exists, duplicate keys not allowed", key)));
+        }
+
+        if (key.length() > MAX_KEY_FIELD_LENGTH) {
+            return Optional.of(Errors.from(format("Maximum key field length is [ %s ]", MAX_KEY_FIELD_LENGTH)));
+        }
+
+        if (payload.get(key).asText().length() > MAX_VALUE_FIELD_LENGTH) {
+            return Optional.of(Errors.from(format("Maximum value field length is [ %s ]", MAX_VALUE_FIELD_LENGTH)));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.products.validations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.products.model.ProductMetadata;
+import uk.gov.pay.products.util.Errors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ProductsMetadataRequestValidatorTest {
+
+    private ProductsMetadataRequestValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new ProductsMetadataRequestValidator();
+    }
+
+    @Test
+    public void shouldErrorWhenExistingMetadataListSizeIs10() {
+        List<ProductMetadata> metadataList = new ArrayList<>();
+        for (int x = 0; x < 10; x++) {
+            metadataList.add(new ProductMetadata(1, "" + x, "" + x));
+        }
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put("key", "value")
+                                .build());
+        Optional<Errors> errors = validator.validateCreateRequest(payload, metadataList);
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Maximum number of allowed metadata [ 10 ] exceeded"), is(true));
+    }
+
+    @Test
+    public void shouldErrorOnEmptyPayload() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                        .build());
+        Optional<Errors> errors = validator.validateCreateRequest(payload, List.of());
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Empty payload is not allowed"), is(true));
+    }
+
+    @Test
+    public void shouldErrorOnMoreThanOneKeyValuePairs() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put("key1", "value1")
+                                .put("key2", "value2")
+                                .build());
+        Optional<Errors> errors = validator.validateCreateRequest(payload, List.of());
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Only one key-value pair is allowed"), is(true));
+    }
+
+    @Test
+    public void shouldErrorOnDuplicateKey() {
+        List<ProductMetadata> metadataList = List.of(new ProductMetadata(1, "Location", "london"),
+                new ProductMetadata(1, "city", "London"));
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put("location", "UK")
+                                .build());
+        Optional<Errors> errors = validator.validateCreateRequest(payload, metadataList);
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Key [ location ] already exists, duplicate keys not allowed"), is(true));
+    }
+
+    @Test
+    public void shouldErrorOnTooLongKeyField() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put("1234567890123456789012345678901", "value")
+                                .build());
+        Optional<Errors> errors = validator.validateCreateRequest(payload, List.of());
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Maximum key field length is [ 30 ]"), is(true));
+    }
+
+    @Test
+    public void shouldErrorOnTooLongValueField() {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(
+                        ImmutableMap.<String, String>builder()
+                                .put("key", "123456789012345678901234567890123456789012345678901")
+                                .build());
+        Optional<Errors> errors = validator.validateCreateRequest(payload, List.of());
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Maximum value field length is [ 50 ]"), is(true));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- keys have to be unique (case insensitive) compared to existing keys
- only one key-value pair is allowed
- keys are limited to 20 characters
- values are limited to 50 characters

- add tests
