### PR TITLE
PP-6160 add a selfservice pact test for a paymentlink with metadata

### DIFF
--- a/src/test/java/uk/gov/pay/products/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/ContractTest.java
@@ -74,4 +74,14 @@ public abstract class ContractTest {
                 .build()
                 .toProduct());
     }
+
+    @State("a product with gateway account id 42 and metadata exist")
+    public void aProductsWithMetadataExistForGatewayAccount() {
+        Product productWithMetadata = aProductEntity()
+                .withGatewayAccountId(42)
+                .build()
+                .toProduct();
+        dbHelper.addProduct(productWithMetadata);
+        dbHelper.addMetadata(productWithMetadata.getExternalId(), "key", "value");
+    }
 }

--- a/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.products.pact;
 
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -11,5 +12,6 @@ import org.junit.runner.RunWith;
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
+@IgnoreNoPactsToVerify
 public class SelfServiceContractTest extends ContractTest {
 }


### PR DESCRIPTION
## WHAT YOU DID
- add a selfservice pact test that includes metadata for a paymentlink

