### PR TITLE
PP-6153 Add ErrorIdentifier field to Errors object

### DIFF
--- a/src/main/java/uk/gov/pay/products/util/Errors.java
+++ b/src/main/java/uk/gov/pay/products/util/Errors.java
@@ -1,16 +1,26 @@
 package uk.gov.pay.products.util;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Errors {
 
     private List<String> errors;
+    @JsonProperty("error_identifier")
+    private String errorIdentifier;
 
     private Errors(@JsonProperty("errors") List<String> errors) {
+        this.errors = errors;
+        this.errorIdentifier = null;
+    }
+
+    private Errors(@JsonProperty("errors") List<String> errors, String errorIdentifier) {
+        this.errorIdentifier = errorIdentifier;
         this.errors = errors;
     }
 
@@ -20,6 +30,10 @@ public class Errors {
 
     public static Errors from(List<String> errorList) {
         return new Errors(errorList);
+    }
+
+    public static Errors from(String error, String errorIdentifier) { 
+        return new Errors(Collections.singletonList(error), errorIdentifier);
     }
 
     @JsonGetter

--- a/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
@@ -25,7 +25,7 @@ public class ProductsMetadataRequestValidator {
 
     public Optional<Errors> validateCreateRequest(JsonNode payload, List<ProductMetadata> existingMetadataList) {
         if (existingMetadataList.size() >= MAX_NUMBER_OF_METADATA_ALLOWED) {
-            return Optional.of(Errors.from(MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG));
+            return Optional.of(Errors.from(MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG, "MAX_METADATA_LENGTH_EXCEEDED"));
         }
         String key = payload.fieldNames().next();
         if (existingMetadataList
@@ -33,7 +33,8 @@ public class ProductsMetadataRequestValidator {
                 .map(ProductMetadata::getKey)
                 .map(String::toLowerCase)
                 .anyMatch(isEqual(key.toLowerCase()))) {
-            return Optional.of(Errors.from(format(DUPLICATE_KEY_ERROR_MSG, key)));
+            return Optional.of(Errors.from(format(DUPLICATE_KEY_ERROR_MSG, key),
+                    "DUPLICATE_METADATA_KEYS"));
         }
 
         return Optional.empty();
@@ -62,11 +63,11 @@ public class ProductsMetadataRequestValidator {
         String key = payload.fieldNames().next();
 
         if (key.length() > MAX_KEY_FIELD_LENGTH) {
-            return Optional.of(Errors.from(MAX_KEY_FIELD_ERROR_MSG));
+            return Optional.of(Errors.from(MAX_KEY_FIELD_ERROR_MSG, "KEY_LENGTH_OVER_MAX_SIZE"));
         }
 
         if (payload.get(key).asText().length() > MAX_VALUE_FIELD_LENGTH) {
-            return Optional.of(Errors.from(MAX_VALUE_FILED_ERROR_MSG));
+            return Optional.of(Errors.from(MAX_VALUE_FILED_ERROR_MSG, "VALUE_LENGTH_OVER_MAX_SIZE"));
         }
 
         return Optional.empty();

--- a/src/test/java/uk/gov/pay/products/resources/ProductMetadataResourceITest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductMetadataResourceITest.java
@@ -64,6 +64,7 @@ public class ProductMetadataResourceITest extends IntegrationTest {
                 .post(format("/v1/api/products/%s/metadata", product.getExternalId()))
                 .then()
                 .statusCode(400)
+                .body("error_identifier", is("DUPLICATE_METADATA_KEYS"))
                 .body("errors", hasSize(1))
                 .body("errors[0]", is(format("Key [ %s ] already exists, duplicate keys not allowed", "location")));;
     }


### PR DESCRIPTION
- Adds an `ErrorIdentifier` field to the Errors object, allowing for
extra descriptive information to be returned if needed.

- Adds a test to ensure this functionality is as expected.
