### PR TITLE
PP-6157 Add Delete Endpoint For Metadata

### DIFF
--- a/src/main/java/uk/gov/pay/products/resources/ProductMetadataResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductMetadataResource.java
@@ -9,6 +9,7 @@ import uk.gov.pay.products.service.ProductsMetadataFactory;
 import uk.gov.pay.products.validations.ProductsMetadataRequestValidator;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -20,6 +21,7 @@ import java.util.List;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/api/products/{productExternalId}/metadata")
+@Produces(APPLICATION_JSON)
 public class ProductMetadataResource {
 
     private static final Logger logger = LoggerFactory.getLogger(ProductMetadataResource.class);
@@ -34,7 +36,6 @@ public class ProductMetadataResource {
     }
 
     @POST
-    @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response createMetadata(@PathParam("productExternalId") String productExternalId, JsonNode payload) {
         logger.info("Create product metadata for id - [ {} ]", productExternalId);
@@ -53,7 +54,6 @@ public class ProductMetadataResource {
     }
 
     @PATCH
-    @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response updateMetadata(@PathParam("productExternalId") String productExternalId, JsonNode payload) {
         logger.info("Update product metadata for id - [ {} ]", productExternalId);
@@ -68,5 +68,15 @@ public class ProductMetadataResource {
                            metadataFactory.metadataUpdater().updateMetadata(payload, productExternalId);
                            return Response.status(Response.Status.OK).build();
                        }));
+    }
+
+    @DELETE
+    @Path("/{metadataKey}")
+    public Response deleteMetadata(@PathParam("productExternalId") String productExternalId, @PathParam("metadataKey") String metadataKey) {
+        logger.info("Delete product metadata for id - [ {} ] with key id [ {} ]", productExternalId, metadataKey);
+
+        metadataFactory.metadataDeleter().deleteMetadata(productExternalId, metadataKey);
+
+        return Response.status(Response.Status.OK).build();
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/ProductsMetadataDeleter.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductsMetadataDeleter.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.products.service;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.products.exception.MetadataNotFoundException;
+import uk.gov.pay.products.persistence.dao.ProductMetadataDao;
+
+public class ProductsMetadataDeleter {
+
+    private ProductMetadataDao productMetadataDao;
+
+    @Inject
+    public ProductsMetadataDeleter(ProductMetadataDao productMetadataDao) {
+        this.productMetadataDao = productMetadataDao;
+    }
+
+    @Transactional
+    public void deleteMetadata(String productExternalId, String metadataKey) throws MetadataNotFoundException {
+        productMetadataDao.findByProductsExternalIdAndKey(productExternalId, metadataKey)
+                .ifPresentOrElse(productMetadataEntity -> productMetadataDao.remove(productMetadataEntity),
+                        () -> { throw new MetadataNotFoundException(productExternalId, metadataKey); });
+    }
+}

--- a/src/main/java/uk/gov/pay/products/service/ProductsMetadataFactory.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductsMetadataFactory.java
@@ -4,4 +4,5 @@ public interface ProductsMetadataFactory {
     ProductsMetadataFinder metadataFinder();
     ProductsMetadataCreator metadataCreator();
     ProductsMetadataUpdater metadataUpdater();
+    ProductsMetadataDeleter metadataDeleter();
 }

--- a/src/test/java/uk/gov/pay/products/resources/ProductMetadataResourceITest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductMetadataResourceITest.java
@@ -120,4 +120,58 @@ public class ProductMetadataResourceITest extends IntegrationTest {
                 .body("errors", hasSize(1))
                 .body("errors[0]", is(format("Key [ %s ] does not exist", "Country")));;
     }
+
+    @Test
+    public void deleteMetadata_succeeds_whenItExists() {
+        String productExternalId = randomUuid();
+        Product product = aProductEntity()
+                .withExternalId(productExternalId)
+                .withGatewayAccountId(0)
+                .withLanguage(SupportedLanguage.WELSH)
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(product);
+        databaseHelper.addMetadata(productExternalId, "Location", "United Kingdom");
+
+        List<Map<String, Object>> preMetadata = databaseHelper.findMetadataByProductExternalId(productExternalId);
+        assertThat(preMetadata.size(), is(1));
+
+        givenSetup()
+                .accept(APPLICATION_JSON)
+                .delete(format("/v1/api/products/%s/metadata/%s", product.getExternalId(), "Location"))
+                .then()
+                .statusCode(200);
+
+        List<Map<String, Object>> metadata = databaseHelper.findMetadataByProductExternalId(productExternalId);
+        assertThat(metadata.size(), is(0));
+    }
+
+    @Test
+    public void deleteMetadata_fails_whenProductDoesNotExist() {
+        String productExternalId = randomUuid();
+        Product product = aProductEntity()
+                .withExternalId(productExternalId)
+                .withGatewayAccountId(0)
+                .withLanguage(SupportedLanguage.WELSH)
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(product);
+        databaseHelper.addMetadata(productExternalId, "Location", "United Kingdom");
+
+        List<Map<String, Object>> preMetadata = databaseHelper.findMetadataByProductExternalId(productExternalId);
+        assertThat(preMetadata.size(), is(1));
+
+        givenSetup()
+                .accept(APPLICATION_JSON)
+                .delete(format("/v1/api/products/%s/metadata/%s", product.getExternalId(), "DoesNotExist"))
+                .then()
+                .statusCode(404)
+                .body("errors", hasSize(1))
+                .body("errors[0]", is(format("Metadata for id [ %s ] and key [ %s ] not found", product.getExternalId(), "DoesNotExist")));
+
+        List<Map<String, Object>> metadata = databaseHelper.findMetadataByProductExternalId(productExternalId);
+        assertThat(metadata.size(), is(1));
+    }
 }


### PR DESCRIPTION
- Adds a DELETE endpoint for metadata which allows for metadata on a
product to be removed via an API.

- Adds tests to ensure happy and failure paths both work as expected.
