### PR TITLE
PP-6254 Add carbon-relay

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -38,6 +38,8 @@ applications:
       PRODUCTSUI_CONFIRMATION_URL: ""
       BASE_URL: ""
       PRODUCTS_FRIENDLY_BASE_URI: ""
+      METRICS_HOST: ""
+      METRICS_PORT: ""
 
       # Provide via products-db service see env-map.yml
       DB_HOST: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -9,5 +9,7 @@ env_vars:
   PRODUCTSUI_CONFIRMATION_URL: '.[][] | select(.name == "app-catalog") | .credentials.products_ui_confirmation_url  '
   PRODUCTS_FRIENDLY_BASE_URI:  '.[][] | select(.name == "app-catalog") | .credentials.products_ui_redirect_url      '
   BASE_URL:                    '.[][] | select(.name == "app-catalog") | .credentials.products_url                  '
+  METRICS_HOST:                '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_route'
+  METRICS_PORT:                '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_port'
   SENTRY_DSN:                  '.[][] | select(.name == "products-secret-service") | .credentials.sentry_dsn        '
   PRODUCTS_API_TOKEN:          '.[][] | select(.name == "products-secret-service") | .credentials.products_api_token'


### PR DESCRIPTION
Set the METRICS_HOST and METRICS_PORT from the app-catalog to send
metrics to the carbon-relay app.
