### PR TITLE
PP-6444 Rename Integration Test so it only runs under verify goal

### DIFF
--- a/src/test/java/uk/gov/pay/products/resources/ProductMetadataResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductMetadataResourceIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.pay.products.fixtures.ProductEntityFixture.aProductEntity;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
-public class ProductMetadataResourceITest extends IntegrationTest {
+public class ProductMetadataResourceIT extends IntegrationTest {
 
     @Test
     public void addNewMetadataShouldSucceed() throws Exception {


### PR DESCRIPTION
Surefire plugin which runs the `test` goal includes `**/*Test.java`
(amongst other patterns) so the `ProductMetadataResourceITest` was
running with `mvn test`. This renames it to `ProductMetadataResourceIT` so it
runs with the `verify` goal (Failsafe plugin). This follows our
separation of unit and integration tests.
