### PR TITLE
PP-6445 Make Pact Broker Host configurable

### DIFF
--- a/src/test/java/uk/gov/pay/products/pact/ProductsUIContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/ProductsUIContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("products")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"products-ui"})
 public class ProductsUIContractTest extends ContractTest {

--- a/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("products")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 @IgnoreNoPactsToVerify


### PR DESCRIPTION
We're using a different pact broker for ci on concourse so make the pact
broker host configurable. The default value is the existing broker used
by Jenkins CI.
