### PR TITLE
BAU fix mvn verify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,22 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>false</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>


### PR DESCRIPTION
## WHAT YOU DID
- The pom references the dropwizard-dependencies as a parent which includes an execution rule for maven-dependency plugin:analyze-only setting the failOnWarning to true (the default is false). This plugin is run as part of the verify phase. We have undeclared transitive dependencies so the analyze-only goal fails and consequently the build.
