### PR TITLE
WIP Fix findByProductsId

### DIFF
--- a/src/main/java/uk/gov/pay/products/persistence/dao/ProductMetadataDao.java
+++ b/src/main/java/uk/gov/pay/products/persistence/dao/ProductMetadataDao.java
@@ -17,7 +17,7 @@ public class ProductMetadataDao extends JpaDao<ProductMetadataEntity> {
 
     public List<ProductMetadataEntity> findByProductsId(Integer productId) {
         String query = "SELECT metadata FROM ProductMetadataEntity metadata " +
-                "WHERE metadata.id = :productId";
+                "WHERE metadata.productEntity.id = :productId";
 
         return entityManager.get()
                 .createQuery(query, ProductMetadataEntity.class)


### PR DESCRIPTION
    WIP Fix findByProductsId

    This method was searching with the `productId` but matching on the `id` of
    the `metadataEntity` rather than the `productEntity`. The tests were
    passing because they only ever created one `productEntity` and one
    `metadataEntity` so the sequential table ids always matched.

TODO:
I don't think we need this dao function since the corresponding service function isn't used by anything other than a test: **https://github.com/alphagov/pay-products/blob/0ebadf89d9df6ff82fc22ae14aed89fe7ee1b737/src/main/java/uk/gov/pay/products/service/ProductsMetadataFinder.java#L23**

Check whether that's right and if so remove the function and its tests. Might be worth checking out the other functions.

## WHAT YOU DID ##
Worth validating this since I'm on holiday tomorrow and I'm scribbling this down before I go....if I'm mistaken the please close it and carry on about your day

This was highlighted when testing on Concourse. This test consistently failed: https://github.com/alphagov/pay-products/blob/master/src/test/java/uk/gov/pay/products/persistence/dao/ProductMetadataDaoIT.java#L58

For some reason the truncating of tables doesn't seem to work quite as expected running on Concourse which means there are multiple products and associated metadata. This results in `productEntity.id != metadata.id` which highlights this problem. When the IT tests run as expected the `metadata.id == product.id` (they are both `1`) and this isn't noticed. In the example below the test using the unmodified doa function is trying to find rows where the `id` is `23` but it should be looking in the `product_id` column instead, however it finds nothing and the test fails.
```
postgres=# select * from products_metadata;
 id | product_id | metadata_key | metadata_value | version
----+------------+--------------+----------------+---------
  1 |          5 | key          | value          |       0
  2 |          5 | secondkey    | value2         |       0
  3 |         23 | a key        | a value        |       1
```

Would be worth checking the other methods and tests to be sure.

