### PR TITLE
PP-7067 Alter type of metadata_value column to be VARCHAR(100)

### DIFF
--- a/src/main/resources/migrations/00036_alter_column_metadata_value_to_varchar_100.sql
+++ b/src/main/resources/migrations/00036_alter_column_metadata_value_to_varchar_100.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:alter_column_metadata_value
+ALTER TABLE products_metadata ALTER COLUMN metadata_value TYPE VARCHAR(100);
+-- rollback alter table products_metadata alter column metadata_value type varchar(50);
+


### PR DESCRIPTION
Database migration to alter the type of the `metadata_value` column of the `products_metadata` table from `VARCHAR(50)` to `VARCHAR(100)`.

Tested this locally and it did the right thing.

The version of PostgreSQL we use is recent enough increasing the size of a `VARCHAR` column does not rewrite the entire table. It does require an access exclusive lock on the table but in production `products_metadata` only has 90 rows so this will be fine.