### PR TITLE
PP-7067 Increase maximum metadata value length from 50 to 100

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-09-08T08:03:19Z",
+  "generated_at": "2020-09-14T12:31:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -83,22 +83,6 @@
         "is_verified": false,
         "line_number": 14,
         "type": "Base64 High Entropy String"
-      }
-    ],
-    "src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java": [
-      {
-        "hashed_secret": "a0639ce4aaf8ca0849eaaba4d57590cf389e3086",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 90,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "0d27ee269eecfb5767295a95755318d3457a431d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 103,
-        "type": "Hex High Entropy String"
       }
     ]
   },

--- a/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.products.validations;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.products.model.ProductMetadata;
 import uk.gov.pay.products.util.Errors;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -12,29 +14,27 @@ import static java.util.function.Predicate.isEqual;
 
 public class ProductsMetadataRequestValidator {
 
-    private static final int MAX_NUMBER_OF_METADATA_ALLOWED = 10;
-    private static final int MAX_KEY_FIELD_LENGTH = 30;
-    private static final int MAX_VALUE_FIELD_LENGTH = 50;
-    private static final String MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG = format("Maximum number of allowed metadata [ %s ] exceeded", MAX_NUMBER_OF_METADATA_ALLOWED);
+    private static final String MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG = format("Maximum number of allowed metadata [ %s ] exceeded",
+            ExternalMetadata.MAX_KEY_VALUE_PAIRS);
     private static final String EMPTY_PAYLOAD_ERROR_MSG = "Empty payload is not allowed";
     private static final String MORE_THAN_ONE_KEY_VALUE_PAIR_ERROR_MSG = "Only one key-value pair is allowed";
     private static final String DUPLICATE_KEY_ERROR_MSG = "Key [ %s ] already exists, duplicate keys not allowed";
     private static final String NON_EXISTENT_KEY_ERROR_MSG = "Key [ %s ] does not exist";
-    private static final String MAX_KEY_FIELD_ERROR_MSG = format("Maximum key field length is [ %s ]", MAX_KEY_FIELD_LENGTH);
-    private static final String MAX_VALUE_FILED_ERROR_MSG = format("Maximum value field length is [ %s ]", MAX_VALUE_FIELD_LENGTH);
+    private static final String MAX_KEY_FIELD_ERROR_MSG = format("Maximum key field length is [ %s ]", ExternalMetadata.MAX_KEY_LENGTH);
+    private static final String MAX_VALUE_FILED_ERROR_MSG = format("Maximum value field length is [ %s ]", ExternalMetadata.MAX_VALUE_LENGTH);
 
     public Optional<Errors> validateCreateRequest(JsonNode payload, List<ProductMetadata> existingMetadataList) {
-        if (existingMetadataList.size() >= MAX_NUMBER_OF_METADATA_ALLOWED) {
+        if (existingMetadataList.size() >= ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
             return Optional.of(Errors.from(MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG, "MAX_METADATA_LENGTH_EXCEEDED"));
         }
+
         String key = payload.fieldNames().next();
         if (existingMetadataList
                 .stream()
                 .map(ProductMetadata::getKey)
                 .map(String::toLowerCase)
-                .anyMatch(isEqual(key.toLowerCase()))) {
-            return Optional.of(Errors.from(format(DUPLICATE_KEY_ERROR_MSG, key),
-                    "DUPLICATE_METADATA_KEYS"));
+                .anyMatch(isEqual(key.toLowerCase(Locale.ENGLISH)))) {
+            return Optional.of(Errors.from(format(DUPLICATE_KEY_ERROR_MSG, key),"DUPLICATE_METADATA_KEYS"));
         }
 
         return Optional.empty();
@@ -42,18 +42,18 @@ public class ProductsMetadataRequestValidator {
 
     public Optional<Errors> validateUpdateRequest(JsonNode payload, List<ProductMetadata> existingMetadataList) {
         String key = payload.fieldNames().next();
-        if (!existingMetadataList
+        if (existingMetadataList
                 .stream()
                 .map(ProductMetadata::getKey)
                 .map(String::toLowerCase)
-                .anyMatch(isEqual(key.toLowerCase()))) {
+                .noneMatch(isEqual(key.toLowerCase(Locale.ENGLISH)))) {
             return Optional.of(Errors.from(format(NON_EXISTENT_KEY_ERROR_MSG, key)));
         }
         return Optional.empty();
     }
 
     public Optional<Errors> validateRequest(JsonNode payload) {
-        if(payload.isEmpty()) {
+        if (payload.isEmpty()) {
             return Optional.of(Errors.from(EMPTY_PAYLOAD_ERROR_MSG));
         }
         if (payload.size() > 1) {
@@ -62,11 +62,11 @@ public class ProductsMetadataRequestValidator {
 
         String key = payload.fieldNames().next();
 
-        if (key.length() > MAX_KEY_FIELD_LENGTH) {
+        if (key.length() > ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
             return Optional.of(Errors.from(MAX_KEY_FIELD_ERROR_MSG, "KEY_LENGTH_OVER_MAX_SIZE"));
         }
 
-        if (payload.get(key).asText().length() > MAX_VALUE_FIELD_LENGTH) {
+        if (payload.get(key).asText().length() > ExternalMetadata.MAX_VALUE_LENGTH) {
             return Optional.of(Errors.from(MAX_VALUE_FILED_ERROR_MSG, "VALUE_LENGTH_OVER_MAX_SIZE"));
         }
 


### PR DESCRIPTION
Update `ProductsMetadataRequestValidator` (and its unit tests) to rely on constants in ExternalMetadata (which is imported from Pay Java commons) for things like the maximum number of characters allowed for metadata values associated with a product.

This has no functional effect other than increasing the character limit for a metadata value from 50 to 100. The necessary database migration to enable this was commit 32ae783331377b719910ab91df1b521a0f12d59f.

Public API and connector have already been updated to allow 100 characters rather than 50.