### PR TITLE
PP-7067 Fix maximum key length validation check

### DIFF
--- a/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
@@ -62,7 +62,7 @@ public class ProductsMetadataRequestValidator {
 
         String key = payload.fieldNames().next();
 
-        if (key.length() > ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
+        if (key.length() > ExternalMetadata.MAX_KEY_LENGTH) {
             return Optional.of(Errors.from(MAX_KEY_FIELD_ERROR_MSG, "KEY_LENGTH_OVER_MAX_SIZE"));
         }
 

--- a/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
@@ -32,6 +32,15 @@ public class ProductsMetadataRequestValidatorTest {
     }
 
     @Test
+    public void shouldAllowValidPayload() {
+        String maxLengthKey = IntStream.rangeClosed(1, ExternalMetadata.MAX_KEY_LENGTH).mapToObj(i -> "k").collect(joining());
+        String maxLengthValue = IntStream.rangeClosed(1, ExternalMetadata.MAX_VALUE_LENGTH).mapToObj(i -> "v").collect(joining());
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of(maxLengthKey, maxLengthValue));
+        Optional<Errors> errors = validator.validateRequest(payload);
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
     public void shouldErrorWhenExistingMetadataListSizeIsAlreadyAtMaxNumberOfKeyValuePairs() {
         List<ProductMetadata> metadataListWithMaxNumberOfKeyValuePairs = IntStream.rangeClosed(1, ExternalMetadata.MAX_KEY_VALUE_PAIRS)
                 .mapToObj(i -> new ProductMetadata(1, "key " + i, "value " + i))


### PR DESCRIPTION
Due a typo, the maximum key length was being restricted to 10 characters (the number of allowed key-value pairs) rather than 30.