### PR TITLE
PP-7063 Remove payload/ full request body logs

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiRestClient.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiRestClient.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class PublicApiRestClient {
     private static final Logger logger = LoggerFactory.getLogger(PublicApiRestClient.class);
@@ -42,7 +44,10 @@ public class PublicApiRestClient {
 
         if (response.getStatus() == HttpStatus.CREATED_201) {
             PaymentResponse paymentResponse = response.readEntity(PaymentResponse.class);
-            logger.info("Public API client returned payment created - [ {} ]", paymentResponse);
+            logger.info(
+                    "Public API client returned payment created",
+                    kv(PAYMENT_EXTERNAL_ID, paymentResponse.getPaymentId())
+            );
             return paymentResponse;
         }
 
@@ -52,7 +57,9 @@ public class PublicApiRestClient {
     }
 
     public Optional<PaymentResponse> getPayment(String apiToken, String paymentId) {
-        logger.info("Public API client requested finding payment - [ {} ]", paymentId);
+        logger.info("Public API client requested finding payment",
+                kv(PAYMENT_EXTERNAL_ID, paymentId)
+        );
 
         Response response = client
                 .target(buildAbsoluteUrl(format(PAYMENT_PATH, paymentId)))
@@ -62,7 +69,10 @@ public class PublicApiRestClient {
 
         if (response.getStatus() == HttpStatus.OK_200) {
             PaymentResponse paymentResponse = response.readEntity(PaymentResponse.class);
-            logger.info("Public API client returned payment found - [ {} ]", paymentResponse);
+            logger.info(
+                    "Public API client returned payment found",
+                    kv(PAYMENT_EXTERNAL_ID, paymentResponse.getPaymentId())
+            );
             return Optional.of(paymentResponse);
         }
 

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -20,6 +20,9 @@ import java.util.List;
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
+import static uk.gov.pay.products.model.Product.FIELD_GATEWAY_ACCOUNT_ID;
+import static uk.gov.pay.products.model.Product.FIELD_TYPE;
+import static uk.gov.pay.products.model.Product.FIELD_NAME;
 
 @Path("/v1/api")
 public class ProductResource {
@@ -39,7 +42,12 @@ public class ProductResource {
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response createProduct(JsonNode payload) {
-        logger.info("Create Service POST request - [ {} ]", payload);
+        logger.info(
+                "Create Service POST request",
+                kv(GATEWAY_ACCOUNT_ID, payload.get(FIELD_GATEWAY_ACCOUNT_ID)),
+                kv(FIELD_TYPE, payload.get(FIELD_TYPE)),
+                kv(FIELD_NAME, payload.get(FIELD_NAME))
+        );
         return requestValidator.validateCreateRequest(payload)
                 .map(errors -> Response.status(Status.BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -25,8 +25,10 @@ import uk.gov.pay.products.util.PaymentStatus;
 import javax.inject.Inject;
 
 import static java.lang.String.format;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUserFriendlyReference;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 
@@ -129,7 +131,12 @@ public class PaymentCreator {
                 paymentEntity.setNextUrl(getNextUrl(paymentResponse));
                 paymentEntity.setStatus(PaymentStatus.SUBMITTED);
                 paymentEntity.setAmount(paymentResponse.getAmount());
-                logger.info("Payment creation for product external id {} successful {}", paymentEntity.getProductEntity().getExternalId(), paymentEntity);
+                logger.info(
+                        "Payment creation for product external id {} successful",
+                        paymentEntity.getProductEntity().getExternalId(),
+                        kv(PAYMENT_EXTERNAL_ID, paymentEntity.getGovukPaymentId()),
+                        kv("product_external_id", paymentEntity.getProductEntity().getExternalId())
+                );
             } catch (PublicApiResponseErrorException e) {
                 logger.error("Payment creation for product external id {} failed {}", paymentEntity.getProductEntity().getExternalId(), e);
                 paymentEntity.setStatus(PaymentStatus.ERROR);


### PR DESCRIPTION
Stop logging the entire request body sent from the client to prevent
unwanted fields being logged (present and future).

Explicitly include the following fields on payment link creation:
* gateway account ID
* product name
* product type

Use structured logging to only log explicit fields from public API
calls, standard logging keys used where possible.
