### PR TITLE
PP-7293: Add a method to update Product's API key

### DIFF
--- a/src/main/java/uk/gov/pay/products/service/ProductFinder.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductFinder.java
@@ -46,6 +46,17 @@ public class ProductFinder {
     }
 
     @Transactional
+    public Optional<Product> updatePayApiTokenByExternalId(String externalId, String payApiToken) {
+        return productDao.findByExternalId(externalId)
+                .map(productEntity -> {
+                    productEntity.setPayApiToken(payApiToken);
+                    productDao.merge(productEntity);
+                    return Optional.of(productEntity.toProduct());
+                })
+                .orElseGet(Optional::empty);
+    }
+
+    @Transactional
     public Boolean deleteByExternalId(String externalId) {
         return productDao.findByExternalId(externalId)
                 .map(productEntity -> {

--- a/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
@@ -84,6 +84,37 @@ public class ProductFinderTest {
     }
 
     @Test
+    public void updatePayApiTokenByExternalId_shouldUpdateApiToken_whenFound() {
+        String externalId = "1";
+        String oldPayApiToken = "old Pay API token";
+        String newPayApiToken = "new Pay API token";
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setExternalId(externalId);
+        productEntity.setReferenceEnabled(false);
+        productEntity.setPayApiToken(oldPayApiToken);
+        when(productDao.findByExternalId(externalId)).thenReturn(Optional.of(productEntity));
+
+        Optional<Product> productOptional = productFinder.findByExternalId(externalId);
+        assertTrue(productOptional.isPresent());
+        assertThat(productOptional.get().getPayApiToken(), is(oldPayApiToken));
+
+        Optional<Product> updatedProduct = productFinder.updatePayApiTokenByExternalId(externalId, newPayApiToken);
+
+        assertTrue(updatedProduct.isPresent());
+        assertThat(updatedProduct.get().getPayApiToken(), is(newPayApiToken));
+    }
+
+    @Test
+    public void updatePayApiTokenByExternalId_shouldReturnEmpty_whenNotFound() {
+        String externalId = "1";
+        when(productDao.findByExternalId(externalId)).thenReturn(Optional.empty());
+
+        Optional<Product> product = productFinder.updatePayApiTokenByExternalId(externalId, "new Pay API token");
+
+        assertFalse(product.isPresent());
+    }
+
+    @Test
     public void disableByExternalId_shouldDisableProduct_whenFound() {
         String externalId = "1";
         ProductEntity productEntity = new ProductEntity();


### PR DESCRIPTION
Add a new method to enable ProductFinder to update Product's API key in a database using the given product external id. This will allow the key to be rotated immediately if it is compromised.
