### PR TITLE
PP-7293: Add an endpoint to regenerate an api key for a product

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ These products are integrated with GOV.UK Pay so that a user can make payments u
 | `DB_PASSWORD`                 | The password for the `DB_USER` user. |
 | `DB_SSL_OPTION`               | To turn TLS on this value must be set as `ssl=true`. Otherwise must be empty. |
 | `DB_USER`                     | The username to log into the database as. |
+| `EMAIL_ADDRESS_FOR_ROTATING_API_KEYS` | The email address used for rotating API keys. |
 | `JAVA_HOME`                   | The location of the JRE. Set to `/opt/java/openjdk` in the `Dockerfile`. |
 | `JAVA_OPTS`                   | Commandline arguments to pass to the java runtime. Optional. |
 | `JPA_LOG_LEVEL`               | The logging level to set for JPA. Defaults to `WARNING`. |
@@ -27,6 +28,7 @@ These products are integrated with GOV.UK Pay so that a user can make payments u
 | `PRODUCTSUI_PAY_URL`          | The URL of the `pay` endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
 | `PRODUCTS_FRIENDLY_BASE_URI`  | The URL of the products endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
 | `PUBLICAPI_URL`               | The URL to the [publicapi](https://github.com/alphagov/pay-publicapi) microservice |
+| `PUBLICAUTH_URL`              | The URL to the [publicauth](https://github.com/alphagov/pay-publicauth) microservice |
 | `RUN_APP`                     | Set to `true` to run the application. Defaults to `true`. |
 | `RUN_MIGRATION`               | Set to `true` to run a database migration. Defaults to `false`. |
 | `SECURE_RETURN_URLS`          | Set to `false` to allow non-HTTPS URLs for the `return_url` field of a product. Defaults to `true`. |
@@ -44,6 +46,7 @@ The JSON naming convention follows Hypertext Application Language (HAL).
 |[```/v1/api/products```](docs/api_specification.md#post-v1apiproducts)        | POST    |  Creates a new product definition            |
 |[```/v1/api/gateway-account/{gatewayAccountId}/products/{productId}```](docs/api_specification.md#put-v1apigateway\-accountgatewayaccountidproductsproductid)        | PATCH    |  Updates an existing product matching the specified `productId` and belonging to the gateway account specified by `gatewayAccountId`. Returns the product only if if the update is successful.|
 |[```/v1/api/products/{productId}```](docs/api_specification.md#get-v1apiproductsproductid)        | GET    |  Gets an existing product with the specified productId   |
+|[```/v1/api/products/{productId}/regenerate-api-key```](docs/api_specification.md#post-v1apiproductsproductexternalidregenerate\-api\-key)        | POST    |  Regenerates a new API key and replaces an old API key with the new key for the specified `productId`.|
 |[```/v1/api/gateway-account/{gatewayAccountId}/products/{productId}```](docs/api_specification.md#get-v1apigateway\-accountgatewayaccountidproductsproductid)        | GET    |  Gets an existing product with the specified productId that belong to the gateway account specified by gatewayAccountId. Returns the product only if it exists in the given gateway account. Useful to avoid insecure direct object reference. |
 |[```/v1/api/gateway-account/{gatewayAccountId}/products```](docs/api_specification.md#get-v1apigateway\-accountgatewayaccountidproducts)        | GET    |  Gets lists of products that belongs to a gateway account specified by gatewayAccountId  |
 |[```/v1/api/products/{productId}```](docs/api_specification.md#delete-v1apiproductsproductid)        | DELETE    |  Deletes the product with the specified productId   |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -340,6 +340,21 @@ Content-Type: application/json
 #### Response field description 
 same as above(docs/api_specification.md#post-v1apiproducts)
 
+## POST /v1/api/products/{productExternalId}/regenerate-api-key
+
+This endpoint regenerates a new API key and replaces an old API key with the new key for a product with the specified external product id.
+
+Regenerates a new API key and replaces the old API key with the new key if the product exists.
+
+```
+POST /v1/api/products/uier837y735n837475y3847534/regenerate-api-key
+```
+
+### Response example
+
+```
+200 OK
+```
 
 ## PATCH /v1/api/products/{productExternalId}/disable
 

--- a/src/main/java/uk/gov/pay/products/client/publicauth/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicauth/TokenResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.products.client.publicauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TokenResponse {
+    private String token;
+    
+    public TokenResponse() {
+    }
+
+    public TokenResponse(
+            @JsonProperty("token") String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String toString() {
+        return "TokenResponse{" +
+                "token='" + token + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -23,10 +23,16 @@ public class ProductsConfiguration extends Configuration {
     private JPAConfiguration jpaConfiguration;
 
     @NotNull
+    private String emailAddress;
+
+    @NotNull
     private String baseUrl;
 
     @NotNull
     private String publicApiUrl;
+
+    @NotNull
+    private String publicAuthUrl;
 
     @NotNull
     private String productsUiPayUrl;
@@ -67,12 +73,20 @@ public class ProductsConfiguration extends Configuration {
         return jpaConfiguration;
     }
 
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
     public String getBaseUrl() {
         return baseUrl;
     }
 
     public String getPublicApiUrl() {
         return publicApiUrl;
+    }
+
+    public String getPublicAuthUrl() {
+        return publicAuthUrl;
     }
 
     public String getProductsUiPayUrl() {

--- a/src/main/java/uk/gov/pay/products/config/ProductsModule.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsModule.java
@@ -35,6 +35,7 @@ public class ProductsModule extends AbstractModule {
     protected void configure() {
         final Client client = RestClientFactory.buildClient(configuration.getRestClientConfiguration());
 
+        bind(Client.class).toInstance(client);
         bind(ProductsConfiguration.class).toInstance(configuration);
         bind(DataSourceFactory.class).toInstance(configuration.getDataSourceFactory());
         bind(MetricRegistry.class).toInstance(environment.metrics());

--- a/src/main/java/uk/gov/pay/products/model/CreateTokenRequest.java
+++ b/src/main/java/uk/gov/pay/products/model/CreateTokenRequest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.products.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import uk.gov.pay.commons.model.TokenPaymentType;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.UUID.randomUUID;
+import static uk.gov.pay.commons.model.TokenPaymentType.CARD;
+import static uk.gov.pay.products.model.TokenSource.API;
+
+public class CreateTokenRequest {
+
+    @NotNull private final String accountId;
+    @NotNull private final String description;
+    @NotNull private final String createdBy;
+    private final TokenPaymentType tokenPaymentType;
+    private final TokenSource tokenSource;
+    private final TokenLink tokenLink = TokenLink.of(randomUUID().toString());
+
+    @JsonCreator
+    public CreateTokenRequest(@JsonProperty("account_id") String accountId,
+                              @JsonProperty("description") String description,
+                              @JsonProperty("created_by") String createdBy,
+                              @JsonProperty("token_type") TokenPaymentType tokenPaymentType,
+                              @JsonProperty("type") TokenSource tokenSource) {
+        this.accountId = accountId;
+        this.description = description;
+        this.createdBy = createdBy;
+        this.tokenPaymentType = tokenPaymentType == null ? CARD : tokenPaymentType;
+        this.tokenSource = tokenSource == null ? API : tokenSource;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
+    }
+
+    public TokenSource getTokenSource() {
+        return tokenSource;
+    }
+
+    public TokenLink getTokenLink() {
+        return tokenLink;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/model/TokenLink.java
+++ b/src/main/java/uk/gov/pay/products/model/TokenLink.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.products.model;
+
+import java.util.Objects;
+
+public class TokenLink {
+    private final String tokenLink;
+
+    private TokenLink(String tokenLink) {
+        this.tokenLink = Objects.requireNonNull(tokenLink);
+    }
+
+    public static TokenLink of(String tokenLink) {
+        return new TokenLink(tokenLink);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == TokenLink.class) {
+            TokenLink that = (TokenLink) other;
+            return this.tokenLink.equals(that.tokenLink);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return tokenLink.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "token_link " + tokenLink;
+    }
+
+    public String getValue() {
+        return tokenLink;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/model/TokenSource.java
+++ b/src/main/java/uk/gov/pay/products/model/TokenSource.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.products.model;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum TokenSource {
+    API, PRODUCTS;
+    private static final Logger LOGGER = LoggerFactory.getLogger(TokenSource.class);
+
+    public static TokenSource fromString(final String source) {
+        try {
+            return TokenSource.valueOf(source.toUpperCase());
+        } catch (Exception e) {
+            LOGGER.error("Unknown token source: " + source);
+            return API;
+        }
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -74,8 +74,10 @@ jpa:
 jerseyClientConfiguration:
   disabledSecureConnection: "false"
 
+emailAddress: ${EMAIL_ADDRESS_FOR_ROTATING_API_KEYS}
 baseUrl: ${BASE_URL}
 publicApiUrl: ${PUBLICAPI_URL}
+publicAuthUrl: ${PUBLICAUTH_URL}/v1/frontend/auth
 productsUiPayUrl: ${PRODUCTSUI_PAY_URL}
 productsUiConfirmUrl: ${PRODUCTSUI_CONFIRMATION_URL}
 friendlyBaseUri: ${PRODUCTS_FRIENDLY_BASE_URI}

--- a/src/test/java/uk/gov/pay/products/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/IntegrationTest.java
@@ -16,14 +16,19 @@ import static io.restassured.http.ContentType.JSON;
 public class IntegrationTest {
 
     public final static int PUBLIC_API_PORT = PortFactory.findFreePort();
+    public final static int PUBLIC_AUTH_PORT = PortFactory.findFreePort();
     
     @ClassRule
     public static final WireMockRule publicApiRule = new WireMockRule(PUBLIC_API_PORT);
 
     @ClassRule
+    public static final WireMockRule publicAuthRule = new WireMockRule(PUBLIC_AUTH_PORT);
+
+    @ClassRule
     public static final DropwizardAppWithPostgresRule app =
             new DropwizardAppWithPostgresRule("config/test-it-config.yaml",
-                    config("publicApiUrl", "http://localhost:" + PUBLIC_API_PORT));
+                    config("publicApiUrl", "http://localhost:" + PUBLIC_API_PORT),
+                    config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/generate-token"));
 
     protected static DatabaseTestHelper databaseHelper;
     protected static ObjectMapper mapper;

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceTest.java
@@ -1,0 +1,95 @@
+package uk.gov.pay.products.resources;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.products.client.publicauth.TokenResponse;
+import uk.gov.pay.products.config.ProductsConfiguration;
+import uk.gov.pay.products.fixtures.ProductEntityFixture;
+import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.service.ProductFactory;
+import uk.gov.pay.products.service.ProductFinder;
+import uk.gov.pay.products.util.ProductType;
+import uk.gov.pay.products.validations.ProductRequestValidator;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProductResourceTest {
+
+    private static final String PUBLICAUTH_URL = "https://publicauth.url";
+    private ProductResource productResource;
+    
+    @Mock
+    private ProductRequestValidator productRequestValidator;
+
+    @Mock
+    private ProductFactory productFactory;
+    
+    @Mock
+    private Client client;
+    
+    @Mock
+    private ProductsConfiguration productsConfiguration;
+
+    @Before
+    public void setUp() {
+        when(productsConfiguration.getEmailAddress()).thenReturn("pay-products@gov.uk");
+        when(productsConfiguration.getPublicAuthUrl()).thenReturn(PUBLICAUTH_URL);
+
+        productResource = new ProductResource(productRequestValidator, productFactory, client, productsConfiguration);
+    }
+    
+    @Test
+    public void shouldReturn500_whenFailingToUpdateApiKeyForAPaymentLink() {
+        String externalId = randomUuid();
+        Product product = ProductEntityFixture.aProductEntity()
+                .withExternalId(externalId)
+                .withType(ProductType.ADHOC)
+                .build()
+                .toProduct();
+
+        ProductFinder productFinder = setUpProductFinderToReturnAProductUsingExternalId(externalId, product);
+        Response publicAuthResponse = setUpPublicAuthToReturnSuccessfulResponse();
+        TokenResponse tokenResponse = new TokenResponse("New Pay API token");
+        when(publicAuthResponse.readEntity(TokenResponse.class)).thenReturn(tokenResponse);
+        when(productFinder.updatePayApiTokenByExternalId(externalId, tokenResponse.getToken())).thenReturn(Optional.empty());
+
+        Response response = productResource.regenerateProductApiKey(externalId);
+
+        assertThat(response.getStatus(), is(500));
+    }
+
+    private Response setUpPublicAuthToReturnSuccessfulResponse() {
+        WebTarget webTarget = mock(WebTarget.class);
+        when(client.target(PUBLICAUTH_URL)).thenReturn(webTarget);
+        Builder builder = mock(Builder.class);
+        when(webTarget.request()).thenReturn(builder);
+        Response publicAuthResponse = mock(Response.class);
+        when(builder.post(any(Entity.class))).thenReturn(publicAuthResponse);
+        return publicAuthResponse;
+    }
+
+    @NotNull
+    private ProductFinder setUpProductFinderToReturnAProductUsingExternalId(String externalId, Product product) {
+        ProductFinder productFinder = mock(ProductFinder.class);
+        when(productFactory.productFinder()).thenReturn(productFinder);
+        when(productFinder.findByExternalId(externalId)).thenReturn(Optional.of(product));
+        return productFinder;
+    }
+}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -64,8 +64,10 @@ jpa:
 jerseyClientConfiguration:
   disabledSecureConnection: "false"
 
+emailAddress: pay-products@gov.uk
 baseUrl: https://products.url
 publicApiUrl: https://publicapi.url
+publicAuthUrl: https://publicauth.url
 productsUiPayUrl: https://products-ui.url/pay
 productsUiConfirmUrl: https://products.url/confirm
 friendlyBaseUri: https://products-ui.url/products


### PR DESCRIPTION
## What you did
This pull request has three separate commits.
 
1. The first commit adds a new endpoint `v1/api/products/{productId}/regenerate-api-key` to the products resource. It is used to generate a new API token and replaces an old API key with the new key for a product with a specified external id. This endpoint is needed for rotating API key for a product because the key can be compromised. It adds two configs items (`emailAddress` and `publicAuthUrl`). Email address is required for identifying who makes a request for generating a new API key. Public Auth URL address is needed to allow Products application to send a request to Public Authentication application for regenerating a new API token. It adds integration tests to cover the following scenarios.

    * API key for payment link successfully replaced
    * API key for prototype link successfully replaced
    * API key for demo payment successfully replaced
    * New API key cannot be generated
    * Product doesn’t exist
    * API Key is null
    * API Key is empty

2. The second commit adds a unit test case to cover a scenario where a new API key cannot be updated. It is difficult to make Products application to fail to update API key in the database after receiving new API token in the integration test. Unit test allows us to do this.

3. The third commit adds information about two new environment variables and the new endpoint (`/v1/api/products/{productExternalId}/regenerate-api-key`) to README and API specification documentation.

## How to test

- How should it be reviewed? 
It is best to review each commit and run all tests to make sure that there are no failures.

- If manual testing is needed, give suggested testing steps.
Integration and unit tests cover the scenarios mentioned above. It would be nice to test these changes in a development environment.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
Yes, the following two environment variables are added. Please see the first commit. 
    * EMAIL_ADDRESS_FOR_ROTATING_API_KEYS
    * PUBLICAUTH_URL

* Added new API / updated existing API definition
Yes, please see the third commit.

