### PR TITLE
PP-7293: Add a service for handling API token for a product

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,9 @@
         <eclipselink.version>2.7.7</eclipselink.version>
         <guice.version>4.2.3</guice.version>
         <hamcrest.version>2.2</hamcrest.version>
+        <junit5.version>5.7.0</junit5.version>
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>
+        <mockito.version>3.5.15</mockito.version>
         <powermock.version>2.0.7</powermock.version>
         <wiremock.version>2.27.2</wiremock.version>
         <jackson.version>2.11.2</jackson.version>
@@ -204,7 +206,31 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.15</version>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -22,7 +22,9 @@ import uk.gov.pay.products.config.PersistenceServiceInitialiser;
 import uk.gov.pay.products.config.ProductsConfiguration;
 import uk.gov.pay.products.config.ProductsModule;
 import uk.gov.pay.products.exception.mapper.BadPaymentRequestExceptionMapper;
+import uk.gov.pay.products.exception.mapper.FailToReplaceApiTokenExceptionMapper;
 import uk.gov.pay.products.exception.mapper.MetadataNotFoundExceptionMapper;
+import uk.gov.pay.products.exception.mapper.FailToGetNewApiTokenExceptionMapper;
 import uk.gov.pay.products.exception.mapper.PaymentCreationExceptionMapper;
 import uk.gov.pay.products.exception.mapper.PaymentCreatorNotFoundExceptionMapper;
 import uk.gov.pay.products.exception.mapper.ProductNotFoundExceptionMapper;
@@ -113,6 +115,8 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
         jersey.register(PaymentCreationExceptionMapper.class);
         jersey.register(PaymentCreatorNotFoundExceptionMapper.class);
         jersey.register(BadPaymentRequestExceptionMapper.class);
+        jersey.register(FailToReplaceApiTokenExceptionMapper.class);
+        jersey.register(FailToGetNewApiTokenExceptionMapper.class);
         jersey.register(ProductNotFoundExceptionMapper.class);
         jersey.register(MetadataNotFoundExceptionMapper.class);
     }

--- a/src/main/java/uk/gov/pay/products/client/publicauth/model/CreateApiTokenRequest.java
+++ b/src/main/java/uk/gov/pay/products/client/publicauth/model/CreateApiTokenRequest.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.products.client.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.commons.model.TokenPaymentType;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateApiTokenRequest {
+    @JsonProperty("account_id")
+    private String accountId;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("created_by")
+    private String createdBy;
+
+    @JsonProperty("token_type")
+    private TokenPaymentType tokenPaymentType;
+
+    @JsonProperty("type")
+    private TokenSource tokenSource;
+
+    public CreateApiTokenRequest() {}
+
+    public CreateApiTokenRequest(String accountId,
+                                 String description,
+                                 String createdBy,
+                                 TokenPaymentType tokenPaymentType,
+                                 TokenSource tokenSource) {
+        this.accountId = accountId;
+        this.description = description;
+        this.createdBy = createdBy;
+        this.tokenPaymentType = tokenPaymentType;
+        this.tokenSource = tokenSource;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public TokenPaymentType getTokenPaymentType() {
+        return tokenPaymentType;
+    }
+
+    public TokenSource getTokenSource() {
+        return tokenSource;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof CreateApiTokenRequest)) {
+            return false;
+        }
+
+        CreateApiTokenRequest that = (CreateApiTokenRequest) o;
+
+        return accountId.equals(that.accountId) &&
+                description.equals(that.description) &&
+                createdBy.equals(that.createdBy) &&
+                tokenPaymentType == that.tokenPaymentType &&
+                tokenSource == that.tokenSource;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, description, createdBy, tokenPaymentType, tokenSource);
+    }
+}

--- a/src/main/java/uk/gov/pay/products/client/publicauth/model/NewApiTokenFromPublicAuthResponse.java
+++ b/src/main/java/uk/gov/pay/products/client/publicauth/model/NewApiTokenFromPublicAuthResponse.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.products.client.publicauth.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NewApiTokenFromPublicAuthResponse {
+    @JsonProperty
+    private String token;
+
+    public NewApiTokenFromPublicAuthResponse() {}
+
+    public NewApiTokenFromPublicAuthResponse(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/client/publicauth/model/TokenSource.java
+++ b/src/main/java/uk/gov/pay/products/client/publicauth/model/TokenSource.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.products.client.publicauth.model;
+
+public enum TokenSource {
+    API, PRODUCTS;
+}

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -29,6 +29,9 @@ public class ProductsConfiguration extends Configuration {
     private String publicApiUrl;
 
     @NotNull
+    private String publicAuthUrl;
+
+    @NotNull
     private String productsUiPayUrl;
 
     @NotNull
@@ -39,6 +42,9 @@ public class ProductsConfiguration extends Configuration {
 
     @NotNull
     private boolean returnUrlMustBeSecure = true;
+
+    @NotNull
+    private String emailAddressForReplacingApiTokens;
 
     public String getVcapServices() {
         return System.getenv("VCAP_SERVICES");
@@ -75,6 +81,10 @@ public class ProductsConfiguration extends Configuration {
         return publicApiUrl;
     }
 
+    public String getPublicAuthUrl() {
+        return publicAuthUrl;
+    }
+
     public String getProductsUiPayUrl() {
         return productsUiPayUrl;
     }
@@ -90,5 +100,9 @@ public class ProductsConfiguration extends Configuration {
 
     public boolean getReturnUrlMustBeSecure() {
         return returnUrlMustBeSecure;
+    }
+
+    public String getEmailAddressForReplacingApiTokens() {
+        return emailAddressForReplacingApiTokens;
     }
 }

--- a/src/main/java/uk/gov/pay/products/exception/FailToGetNewApiTokenException.java
+++ b/src/main/java/uk/gov/pay/products/exception/FailToGetNewApiTokenException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.products.exception;
+
+public class FailToGetNewApiTokenException extends RuntimeException {
+
+    public FailToGetNewApiTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/products/exception/FailToReplaceApiTokenException.java
+++ b/src/main/java/uk/gov/pay/products/exception/FailToReplaceApiTokenException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.products.exception;
+
+public class FailToReplaceApiTokenException extends RuntimeException {
+
+    public FailToReplaceApiTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/products/exception/mapper/FailToGetNewApiTokenExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/FailToGetNewApiTokenExceptionMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.products.exception.mapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.products.exception.FailToGetNewApiTokenException;
+import uk.gov.pay.products.util.Errors;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class FailToGetNewApiTokenExceptionMapper implements ExceptionMapper<FailToGetNewApiTokenException> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Response toResponse(FailToGetNewApiTokenException exception) {
+        logger.error("FailToGetNewApiTokenException thrown.", exception);
+        return Response
+                .status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(Errors.from(exception.getMessage()))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/products/exception/mapper/FailToReplaceApiTokenExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/FailToReplaceApiTokenExceptionMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.products.exception.mapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.products.exception.FailToReplaceApiTokenException;
+import uk.gov.pay.products.util.Errors;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class FailToReplaceApiTokenExceptionMapper implements ExceptionMapper<FailToReplaceApiTokenException> {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public Response toResponse(FailToReplaceApiTokenException exception) {
+        logger.error("FailToReplaceApiTokenException thrown.", exception);
+        return Response
+                .status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(Errors.from(exception.getMessage()))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/products/service/ProductApiTokenManager.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductApiTokenManager.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.products.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.products.client.publicauth.model.CreateApiTokenRequest;
+import uk.gov.pay.products.client.publicauth.model.NewApiTokenFromPublicAuthResponse;
+import uk.gov.pay.products.config.ProductsConfiguration;
+import uk.gov.pay.products.exception.FailToGetNewApiTokenException;
+import uk.gov.pay.products.exception.FailToReplaceApiTokenException;
+import uk.gov.pay.products.model.Product;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static uk.gov.pay.commons.model.TokenPaymentType.CARD;
+import static uk.gov.pay.products.client.publicauth.model.TokenSource.PRODUCTS;
+
+public class ProductApiTokenManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProductApiTokenManager.class);
+    public static final String NEW_API_TOKEN_PATH = "/v1/frontend/auth";
+
+    private final Client client;
+    private final String publicAuthUrl;
+    private final String emailAddressForReplacingApiTokens;
+    private final ProductFactory productFactory;
+
+    @Inject
+    public ProductApiTokenManager(Client client, ProductsConfiguration configuration, ProductFactory productFactory) {
+        this.client = client;
+        this.emailAddressForReplacingApiTokens = configuration.getEmailAddressForReplacingApiTokens();
+        this.publicAuthUrl = configuration.getPublicAuthUrl();
+        this.productFactory = productFactory;
+    }
+
+    public String getNewApiTokenFromPublicAuth(Product product) {
+        CreateApiTokenRequest tokenRequest = createApiTokenRequest(product);
+
+        Response response = client.target(publicAuthUrl + NEW_API_TOKEN_PATH)
+                .request()
+                .post(Entity.entity(tokenRequest, MediaType.APPLICATION_JSON));
+
+        return Optional.ofNullable(response.readEntity(NewApiTokenFromPublicAuthResponse.class))
+                .map(NewApiTokenFromPublicAuthResponse::getToken)
+                .orElseThrow(() -> new FailToGetNewApiTokenException(
+                        String.format("Failed to get a new API token for product %s of type %s",
+                                product.getExternalId(),
+                                product.getType())));
+    }
+
+    public void replaceApiTokenForAProduct(Product product, String newApiToken) {
+        Product modifiedProduct = productFactory.productFinder().updatePayApiTokenByExternalId(product.getExternalId(), newApiToken)
+                .orElseThrow(() -> new FailToReplaceApiTokenException(
+                        String.format("Failed to replace API token for product %s of type %s",
+                                product.getExternalId(), product.getType())));
+
+        LOGGER.info(String.format("Regenerated API token for product %s of type %s",
+                modifiedProduct.getExternalId(), modifiedProduct.getType()));
+    }
+
+    private CreateApiTokenRequest createApiTokenRequest(Product product) {
+        return new CreateApiTokenRequest(
+                String.valueOf(product.getGatewayAccountId()),
+                getDescription(product),
+                emailAddressForReplacingApiTokens,
+                CARD,
+                PRODUCTS);
+    }
+
+    private String getDescription(Product product) {
+        switch (product.getType()) {
+            case ADHOC:
+                return String.format("Token for \"%s\" payment link", product.getName());
+            case PROTOTYPE:
+                return String.format("Token for Prototype: %s", product.getName());
+            case DEMO:
+                return "Token for Demo Payment";
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Product %s has an invalid product type [%s]",
+                                product.getExternalId(), product.getType().toString()));
+        }
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -74,8 +74,11 @@ jpa:
 jerseyClientConfiguration:
   disabledSecureConnection: "false"
 
+emailAddressForReplacingApiTokens: ${EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS}
+
 baseUrl: ${BASE_URL}
 publicApiUrl: ${PUBLICAPI_URL}
+publicAuthUrl: ${PUBLICAUTH_URL}
 productsUiPayUrl: ${PRODUCTSUI_PAY_URL}
 productsUiConfirmUrl: ${PRODUCTSUI_CONFIRMATION_URL}
 friendlyBaseUri: ${PRODUCTS_FRIENDLY_BASE_URI}

--- a/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
+++ b/src/test/java/uk/gov/pay/products/fixtures/ProductEntityFixture.java
@@ -15,6 +15,7 @@ public class ProductEntityFixture {
 
     private String description = "default description";
     private String name = "default name";
+    private String apiToken = "default api token";
     private Long price = 100L;
     private String returnUrl = "https://return.url";
     private ProductStatus status = ProductStatus.ACTIVE;
@@ -34,7 +35,7 @@ public class ProductEntityFixture {
 
     public ProductEntity build() {
         ProductEntity product = new ProductEntity();
-        product.setPayApiToken("default api key");
+        product.setPayApiToken(apiToken);
         product.setDateCreated(dateCreated);
         product.setDescription(description);
         product.setName(name);
@@ -66,6 +67,11 @@ public class ProductEntityFixture {
 
     public ProductEntityFixture withDescription(String description) {
         this.description = description;
+        return this;
+    }
+
+    public ProductEntityFixture withApiToken(String apiToken) {
+        this.apiToken = apiToken;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/products/service/ProductApiTokenManagerTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductApiTokenManagerTest.java
@@ -5,13 +5,13 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.model.TokenPaymentType;
 import uk.gov.pay.products.client.publicauth.model.CreateApiTokenRequest;
@@ -34,14 +34,14 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.products.service.ProductApiTokenManager.NEW_API_TOKEN_PATH;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProductApiTokenManagerTest {
     private static final String PUBLICAUTH_URL = "https://publicauth.url";
     private static final String EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS = "pay-products@gov.uk";
@@ -66,7 +66,7 @@ public class ProductApiTokenManagerTest {
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logger.addAppender(mockAppender);

--- a/src/test/java/uk/gov/pay/products/service/ProductApiTokenManagerTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductApiTokenManagerTest.java
@@ -1,0 +1,184 @@
+package uk.gov.pay.products.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.TokenPaymentType;
+import uk.gov.pay.products.client.publicauth.model.CreateApiTokenRequest;
+import uk.gov.pay.products.client.publicauth.model.NewApiTokenFromPublicAuthResponse;
+import uk.gov.pay.products.client.publicauth.model.TokenSource;
+import uk.gov.pay.products.config.ProductsConfiguration;
+import uk.gov.pay.products.exception.FailToGetNewApiTokenException;
+import uk.gov.pay.products.exception.FailToReplaceApiTokenException;
+import uk.gov.pay.products.fixtures.ProductEntityFixture;
+import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.util.ProductType;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.products.service.ProductApiTokenManager.NEW_API_TOKEN_PATH;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProductApiTokenManagerTest {
+    private static final String PUBLICAUTH_URL = "https://publicauth.url";
+    private static final String EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS = "pay-products@gov.uk";
+    private static final String NEW_API_TOKEN_FOR_DEMO_PAYMENT = "New API token for demo payment";
+    private static final String DEMO_PAYMENT_DESCRIPTION = "Token for Demo Payment";
+    private static final Product DEMO_PAYMENT = ProductEntityFixture.aProductEntity().build().toProduct();
+
+    private ProductApiTokenManager productApiTokenManager;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private ProductsConfiguration productsConfiguration;
+
+    @Mock
+    private ProductFactory productFactory;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Before
+    public void setUp() {
+        final Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        logger.addAppender(mockAppender);
+        logger.setLevel(Level.INFO);
+
+        when(productsConfiguration.getEmailAddressForReplacingApiTokens()).thenReturn(EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS);
+        when(productsConfiguration.getPublicAuthUrl()).thenReturn(PUBLICAUTH_URL);
+
+        productApiTokenManager = new ProductApiTokenManager(client, productsConfiguration, productFactory);
+    }
+
+    @Test
+    public void shouldReturnANewApiTokenForDemoPaymentWhenPublicAuthGeneratesTheToken() {
+        setUpPublicAuthToReturnResponse(DEMO_PAYMENT, NEW_API_TOKEN_FOR_DEMO_PAYMENT, DEMO_PAYMENT_DESCRIPTION);
+
+        String apiToken = productApiTokenManager.getNewApiTokenFromPublicAuth(DEMO_PAYMENT);
+
+        assertThat(apiToken, is(NEW_API_TOKEN_FOR_DEMO_PAYMENT));
+    }
+
+    @Test
+    public void shouldReturnANewApiTokenForPaymentLinkWhenPublicAuthGeneratesTheToken() {
+        final String newApiToken = "New API token for payment link";
+        Product paymentLink = ProductEntityFixture.aProductEntity()
+                .withType(ProductType.ADHOC)
+                .build()
+                .toProduct();
+        setUpPublicAuthToReturnResponse(paymentLink, newApiToken, String.format("Token for \"%s\" payment link", paymentLink.getName()));
+
+        String apiToken = productApiTokenManager.getNewApiTokenFromPublicAuth(paymentLink);
+
+        assertThat(apiToken, is(newApiToken));
+    }
+
+    @Test
+    public void shouldReturnANewApiTokenForPrototypeLinkWhenPublicAuthGeneratesTheToken() {
+        final String newApiToken = "New API token for prototype link";
+        Product prototypeLink = ProductEntityFixture.aProductEntity()
+                .withType(ProductType.PROTOTYPE)
+                .build()
+                .toProduct();
+        setUpPublicAuthToReturnResponse(prototypeLink, newApiToken, String.format("Token for Prototype: %s", prototypeLink.getName()));
+
+        String apiToken = productApiTokenManager.getNewApiTokenFromPublicAuth(prototypeLink);
+
+        assertThat(apiToken, is(newApiToken));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenPublicAuthFailsToGenerateAnApiToken() {
+        setUpPublicAuthToReturnResponse(DEMO_PAYMENT, null, DEMO_PAYMENT_DESCRIPTION);
+
+        FailToGetNewApiTokenException e = assertThrows(FailToGetNewApiTokenException.class,
+                () -> productApiTokenManager.getNewApiTokenFromPublicAuth(DEMO_PAYMENT));
+
+        assertThat(e.getMessage(),
+                is(String.format("Failed to get a new API token for product %s of type %s", DEMO_PAYMENT.getExternalId(), DEMO_PAYMENT.getType())));
+    }
+
+    @Test
+    public void shouldReplaceApiTokenForAProductWhichExists() {
+        Product modifiedDemoPayment = ProductEntityFixture.aProductEntity().withApiToken(NEW_API_TOKEN_FOR_DEMO_PAYMENT).build().toProduct();
+        ProductFinder productFinder = mock(ProductFinder.class);
+        when(productFactory.productFinder()).thenReturn(productFinder);
+        when(productFinder.updatePayApiTokenByExternalId(DEMO_PAYMENT.getExternalId(), NEW_API_TOKEN_FOR_DEMO_PAYMENT)).thenReturn(Optional.of(modifiedDemoPayment));
+
+        productApiTokenManager.replaceApiTokenForAProduct(DEMO_PAYMENT, NEW_API_TOKEN_FOR_DEMO_PAYMENT);
+
+        verifyLog(mockAppender, loggingEventArgumentCaptor, 1,
+                String.format("Regenerated API token for product %s of type %s", modifiedDemoPayment.getExternalId(), modifiedDemoPayment.getType()));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenReplacingApiTokenForAProductWhichDoesNotExist() {
+        ProductFinder productFinder = mock(ProductFinder.class);
+        when(productFactory.productFinder()).thenReturn(productFinder);
+        when(productFinder.updatePayApiTokenByExternalId(DEMO_PAYMENT.getExternalId(), NEW_API_TOKEN_FOR_DEMO_PAYMENT)).thenReturn(Optional.empty());
+
+        FailToReplaceApiTokenException e = assertThrows(FailToReplaceApiTokenException.class,
+                () -> productApiTokenManager.replaceApiTokenForAProduct(DEMO_PAYMENT, NEW_API_TOKEN_FOR_DEMO_PAYMENT));
+
+        assertThat(e.getMessage(),
+                is(String.format("Failed to replace API token for product %s of type %s", DEMO_PAYMENT.getExternalId(), DEMO_PAYMENT.getType())));
+    }
+
+    private void setUpPublicAuthToReturnResponse(Product product,
+                                                 String expectedNewApiToken,
+                                                 String description) {
+        WebTarget webTarget = mock(WebTarget.class);
+        when(client.target(PUBLICAUTH_URL + NEW_API_TOKEN_PATH)).thenReturn(webTarget);
+        Invocation.Builder builder = mock(Invocation.Builder.class);
+        when(webTarget.request()).thenReturn(builder);
+        Response publicAuthResponse = mock(Response.class);
+        CreateApiTokenRequest request = new CreateApiTokenRequest(
+                product.getGatewayAccountId().toString(),
+                description,
+                EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS,
+                TokenPaymentType.CARD,
+                TokenSource.PRODUCTS);
+        when(builder.post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE))).thenReturn(publicAuthResponse);
+        NewApiTokenFromPublicAuthResponse newApiTokenFromPublicAuthResponse = new NewApiTokenFromPublicAuthResponse(expectedNewApiToken);
+        when(publicAuthResponse.readEntity(NewApiTokenFromPublicAuthResponse.class)).thenReturn(newApiTokenFromPublicAuthResponse);
+    }
+
+    private static void verifyLog(
+            final Appender<ILoggingEvent> mockAppender,
+            final ArgumentCaptor<LoggingEvent> captorLoggingEvent,
+            final int expectedNumOfInvocations,
+            final String expectedLogMessage) {
+        verify(mockAppender, times(expectedNumOfInvocations)).doAppend(captorLoggingEvent.capture());
+        final LoggingEvent loggingEvent = captorLoggingEvent.getValue();
+        assertThat(loggingEvent.getLevel(), is(Level.INFO));
+        assertThat(loggingEvent.getFormattedMessage(), is(expectedLogMessage));
+    }
+}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -64,8 +64,11 @@ jpa:
 jerseyClientConfiguration:
   disabledSecureConnection: "false"
 
+emailAddressForReplacingApiTokens: pay-products@gov.uk
+
 baseUrl: https://products.url
 publicApiUrl: https://publicapi.url
+publicAuthUrl: https://publicauth.url
 productsUiPayUrl: https://products-ui.url/pay
 productsUiConfirmUrl: https://products.url/confirm
 friendlyBaseUri: https://products-ui.url/products


### PR DESCRIPTION
## WHAT YOU DID
This change

- adds a new service called Product API Token Manager which is responsible for getting a new API token from Public Auth application and replacing an old API token with a new API token for a specified product.
- introduces two configuration items (`emailAddressForReplacingApiTokens` and `publicAuthUrl`). `emailAddressForReplacingApiTokens` is required for identifying who makes a request for generating a new API token. `publicAuthUrl` is needed by Products application to send a request to Public Auth application for generating a new API token.
- add unit tests to ensure that the service can receive a new API token from the Public Auth application and replace an old API token with a new API token in a database for a given product.

At this moment, Products application is not using this service. There will be a separate pull request for adding a new endpoint which will use this service. This pull request should not be merged until another pull request for adding two environment variables (EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS and PUBLICAUTH_URL) is merged. 

## Code review checklist

### Logging

- [X ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

There will be a pull request for adding a new endpoint for replacing API token for a product. It will include changes to README and API specifications.
 
* Introduced any new environment variables / removed existing environment variable
Yes, the following two environment variables are added. 
    * EMAIL_ADDRESS_FOR_REPLACING_API_KEYS
    * PUBLICAUTH_URL

* Added new API / updated existing API definition