### PR TITLE
PP-7293: Add an endpoint for replacing an old API token with a new API token for a product

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ These products are integrated with GOV.UK Pay so that a user can make payments u
 | `PRODUCTSUI_PAY_URL`          | The URL of the `pay` endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
 | `PRODUCTS_FRIENDLY_BASE_URI`  | The URL of the products endpoint in the [products-ui](https://github.com/alphagov/pay-products-ui) microservice. |
 | `PUBLICAPI_URL`               | The URL to the [publicapi](https://github.com/alphagov/pay-publicapi) microservice |
+| `PUBLICAUTH_URL`              | The URL to the [publicauth](https://github.com/alphagov/pay-publicauth) microservice |
+| `EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS` | The email address used in a request to Public Auth application for generating an API token. |
 | `RUN_APP`                     | Set to `true` to run the application. Defaults to `true`. |
 | `RUN_MIGRATION`               | Set to `true` to run a database migration. Defaults to `false`. |
 | `SECURE_RETURN_URLS`          | Set to `false` to allow non-HTTPS URLs for the `return_url` field of a product. Defaults to `true`. |
@@ -52,4 +54,5 @@ The JSON naming convention follows Hypertext Application Language (HAL).
 |[```/v1/api/payments```](docs/api_specification.md#post-v1apipayments)        | POST    | Creates a new payment                        |
 |[```/v1/api/payments/{paymentId}```](docs/api_specification.md#get-v1apipaymentspaymentid) |  GET  |     Gets an existing payment    |
 |[```/v1/api/products/{productId}/payments```](docs/api_specification.md#get-v1apiproductsproductidpayments) | GET | Gets a list of payments that belong to a specific product specified by productId |
-|[```/v1/api/gateway-account/{gatewayAccountId}```](docs/api_specification.md#get-v1apigatewayaccountgatewayaccountid) | PATCH | Updates a specific field of a given gateway-account of products specified by gatewayAccountId |  
+|[```/v1/api/gateway-account/{gatewayAccountId}```](docs/api_specification.md#get-v1apigatewayaccountgatewayaccountid) | PATCH | Updates a specific field of a given gateway-account of products specified by gatewayAccountId |
+|[```/v1/api/products/{productId}/regenerate-api-token```](docs/api_specification.md#post-v1apiproductsproductexternalidregenerate\-api\-token)        | POST    |  Gets a new API token from Public Auth application and replaces an old API token with the new token for the specified `productId`.|

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -570,3 +570,19 @@ Content-Type: application/json
 | `amount`                 | X              | amount of the payment in pence. |
 | `_links.self`            | X              | self GET link to the payment |
 | `_links.next`            | X              | next GET link |
+
+## POST /v1/api/products/{productExternalId}/regenerate-api-token
+
+This endpoint will get a new API token from Public Auth application and replaces an old API token with the new token for a product with the specified external product id.
+
+Gets a new API token from Public Auth application and replaces the old API token with the new token if the product exists.
+
+```
+POST /v1/api/products/uier837y735n837475y3847534/regenerate-api-token
+```
+
+### Response example
+
+```
+200 OK
+```

--- a/src/main/java/uk/gov/pay/products/config/ProductsModule.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsModule.java
@@ -12,6 +12,7 @@ import uk.gov.pay.products.client.publicapi.PublicApiRestClient;
 import uk.gov.pay.products.service.LinksDecorator;
 import uk.gov.pay.products.service.PaymentFactory;
 import uk.gov.pay.products.service.PaymentFinder;
+import uk.gov.pay.products.service.ProductApiTokenManager;
 import uk.gov.pay.products.service.ProductFactory;
 import uk.gov.pay.products.service.ProductFinder;
 import uk.gov.pay.products.service.ProductsMetadataFactory;
@@ -35,6 +36,7 @@ public class ProductsModule extends AbstractModule {
     protected void configure() {
         final Client client = RestClientFactory.buildClient(configuration.getRestClientConfiguration());
 
+        bind(Client.class).toInstance(client);
         bind(ProductsConfiguration.class).toInstance(configuration);
         bind(DataSourceFactory.class).toInstance(configuration.getDataSourceFactory());
         bind(MetricRegistry.class).toInstance(environment.metrics());
@@ -48,6 +50,7 @@ public class ProductsModule extends AbstractModule {
                         configuration.getFriendlyBaseUri()));
         bind(ProductFinder.class).in(Singleton.class);
         bind(PaymentFinder.class).in(Singleton.class);
+        bind(ProductApiTokenManager.class).in(Singleton.class);
 
         bind(PublicApiRestClient.class).toInstance(
                 new PublicApiRestClient(client, configuration.getPublicApiUrl()));

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -7,22 +7,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.model.ProductUsageStat;
+import uk.gov.pay.products.service.ProductApiTokenManager;
 import uk.gov.pay.products.service.ProductFactory;
 import uk.gov.pay.products.validations.ProductRequestValidator;
-import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
-import static net.logstash.logback.argument.StructuredArguments.kv;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.List;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.pay.products.model.Product.FIELD_GATEWAY_ACCOUNT_ID;
-import static uk.gov.pay.products.model.Product.FIELD_TYPE;
 import static uk.gov.pay.products.model.Product.FIELD_NAME;
+import static uk.gov.pay.products.model.Product.FIELD_TYPE;
 
 @Path("/v1/api")
 public class ProductResource {
@@ -30,11 +40,15 @@ public class ProductResource {
 
     private final ProductRequestValidator requestValidator;
     private final ProductFactory productFactory;
+    private final ProductApiTokenManager productApiTokenManager;
 
     @Inject
-    public ProductResource(ProductRequestValidator requestValidator, ProductFactory productFactory) {
+    public ProductResource(ProductRequestValidator requestValidator,
+                           ProductFactory productFactory,
+                           ProductApiTokenManager productApiTokenManager) {
         this.requestValidator = requestValidator;
         this.productFactory = productFactory;
+        this.productApiTokenManager = productApiTokenManager;
     }
 
     @POST
@@ -182,5 +196,16 @@ public class ProductResource {
         );
         List<ProductUsageStat> usageStats = productFactory.productFinder().findProductsAndUsage(gatewayAccountId);
         return Response.status(OK).entity(usageStats).build();
+    }
+
+    @POST
+    @Path("/products/{productExternalId}/regenerate-api-token")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response regenerateProductApiToken(@PathParam("productExternalId") String productExternalId) {
+        return productFactory.productFinder().findByExternalId(productExternalId).map((product) -> {
+            productApiTokenManager.replaceApiTokenForAProduct(product, productApiTokenManager.getNewApiTokenFromPublicAuth(product));
+            return Response.ok().build();
+        }).orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 }

--- a/src/test/java/uk/gov/pay/products/infra/DropwizardAppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/products/infra/DropwizardAppWithPostgresRule.java
@@ -86,6 +86,10 @@ public class DropwizardAppWithPostgresRule implements TestRule {
         return app.getLocalPort();
     }
 
+    public ProductsConfiguration getConfiguration() {
+        return app.getConfiguration();
+    }
+
     public DatabaseTestHelper getDatabaseTestHelper() {
         return databaseTestHelper;
     }

--- a/src/test/java/uk/gov/pay/products/resources/IntegrationTest.java
+++ b/src/test/java/uk/gov/pay/products/resources/IntegrationTest.java
@@ -16,14 +16,19 @@ import static io.restassured.http.ContentType.JSON;
 public class IntegrationTest {
 
     public final static int PUBLIC_API_PORT = PortFactory.findFreePort();
+    public final static int PUBLIC_AUTH_PORT = PortFactory.findFreePort();
     
     @ClassRule
     public static final WireMockRule publicApiRule = new WireMockRule(PUBLIC_API_PORT);
 
     @ClassRule
+    public static final WireMockRule publicAuthRule = new WireMockRule(PUBLIC_AUTH_PORT);
+
+    @ClassRule
     public static final DropwizardAppWithPostgresRule app =
             new DropwizardAppWithPostgresRule("config/test-it-config.yaml",
-                    config("publicApiUrl", "http://localhost:" + PUBLIC_API_PORT));
+                    config("publicApiUrl", "http://localhost:" + PUBLIC_API_PORT),
+                    config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT));
 
     protected static DatabaseTestHelper databaseHelper;
     protected static ObjectMapper mapper;


### PR DESCRIPTION
## WHAT YOU DID
This pull request has two commits.

1. The first commit adds a new endpoint `v1/api/products/{productId}/regenerate-api-token` to the products resource. It is used to generate a new API token and replaces an old API token with the new token for a product with a specified external id. This endpoint is needed because the API token can be compromised. It also adds integration tests to ensure the the endpoint can return 200 for successfully replacing API token, 500 for failing to replacing it and 404 for the product which does not exist.
2. The second commit adds information about two new environment variables (EMAIL_ADDRESS_FOR_REPLACING_API_TOKENS and PUBLICAUTH_URL) and the new endpoint (/v1/api/products/{productExternalId}/regenerate-api-token) to README and API specification documentation.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
Yes
* Added new API / updated existing API definition
Yes