### PR TITLE
PP-7293: Add connectTimeout and readTimeout to Jersey client

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/products/client/RestClientFactory.java
@@ -16,6 +16,8 @@ public class RestClientFactory {
 
     public static Client buildClient(RestClientConfiguration clientConfig) {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        clientBuilder.connectTimeout(clientConfig.getConnectTimeout().getQuantity(), clientConfig.getConnectTimeout().getUnit());
+        clientBuilder.readTimeout(clientConfig.getReadTimeout().getQuantity(), clientConfig.getReadTimeout().getUnit());
 
         if (!clientConfig.isDisabledSecureConnection()) {
             try {

--- a/src/main/java/uk/gov/pay/products/config/RestClientConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/RestClientConfiguration.java
@@ -1,12 +1,28 @@
 package uk.gov.pay.products.config;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.util.Duration;
+
+import javax.validation.constraints.NotNull;
 
 public class RestClientConfiguration extends Configuration {
     private String disabledSecureConnection;
+
+    @NotNull
+    private Duration connectTimeout = Duration.seconds(50L);
+
+    @NotNull
+    private Duration readTimeout = Duration.seconds(50L);
 
     public Boolean isDisabledSecureConnection() {
         return "true".equals(disabledSecureConnection);
     }
 
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
 }

--- a/src/test/java/uk/gov/pay/products/client/RestClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/products/client/RestClientFactoryTest.java
@@ -1,6 +1,11 @@
 package uk.gov.pay.products.client;
 
-import org.junit.Test;
+import io.dropwizard.util.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.products.config.RestClientConfiguration;
 
 import javax.net.ssl.SSLContext;
@@ -9,36 +14,59 @@ import javax.ws.rs.client.Client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class RestClientFactoryTest {
+    private static final Duration FIFTY_SECONDS = Duration.seconds(50);
+
+    @Mock
+    private RestClientConfiguration clientConfiguration;
+
+    @BeforeEach
+    public void setUp() {
+        when(clientConfiguration.getConnectTimeout()).thenReturn(FIFTY_SECONDS);
+        when(clientConfiguration.getReadTimeout()).thenReturn(FIFTY_SECONDS);
+    }
 
     @Test
     public void jerseyClient_shouldUseSSLWhenSecureInternalCommunicationIsOn() {
-        //given
-        RestClientConfiguration clientConfiguration = mock(RestClientConfiguration.class);
         when(clientConfiguration.isDisabledSecureConnection()).thenReturn(false);
 
-        //when
         Client client = RestClientFactory.buildClient(clientConfiguration);
 
-        //then
         SSLContext sslContext = client.getSslContext();
         assertThat(sslContext.getProtocol(), is("TLSv1.2"));
-
     }
 
     @Test
     public void jerseyClient_shouldNotUseSSLWhenSecureInternalCommunicationIsOff() {
-        //given
-        RestClientConfiguration clientConfiguration = mock(RestClientConfiguration.class);
         when(clientConfiguration.isDisabledSecureConnection()).thenReturn(true);
 
-        //when
         Client client = RestClientFactory.buildClient(clientConfiguration);
 
-        //then
         assertThat(client.getSslContext().getProtocol(), is(not("TLSv1.2")));
+    }
+
+    @Test
+    public void jerseyClient_shouldHaveConnectTimeoutSetTo10s() {
+        Duration connectTimeout = Duration.seconds(10L);
+        when(clientConfiguration.getConnectTimeout()).thenReturn(connectTimeout);
+
+        Client client = RestClientFactory.buildClient(clientConfiguration);
+
+        assertThat(client.getConfiguration().getProperty("jersey.config.client.connectTimeout"),
+                is(Math.toIntExact(connectTimeout.getUnit().toMillis(connectTimeout.getQuantity()))));
+    }
+
+    @Test
+    public void jerseyClient_shouldHaveReadTimeoutSetTo15s() {
+        Duration readTimeout = Duration.seconds(15L);
+        when(clientConfiguration.getReadTimeout()).thenReturn(readTimeout);
+
+        Client client = RestClientFactory.buildClient(clientConfiguration);
+
+        assertThat(client.getConfiguration().getProperty("jersey.config.client.readTimeout"),
+                is(Math.toIntExact(readTimeout.getUnit().toMillis(readTimeout.getQuantity()))));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
Currently, Jersey client has both connectTimeout and readTimeout set to 0 by default. 0 means infinity. When the client sends a request to another application, it waits until it gets a response. If the request is dropped silently by a firewall or it goes missing, the client will wait forever and never log a timeout exception. This change will add both connectTimeout and readTimeout config items to Products application's config file and are set to 50 seconds by default because Nginx's default timeout is 60 seconds and these timeouts need to be less than 60 seconds to allow Products application to send its response before Nginx cuts off. It also updates RestClientFactoryTest to use JUnit5.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
No
* Added new API / updated existing API definition
No