### PR TITLE
PP-7293: Reduce connectTimeout to 25 seconds

### DIFF
--- a/src/main/java/uk/gov/pay/products/config/RestClientConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/RestClientConfiguration.java
@@ -9,7 +9,7 @@ public class RestClientConfiguration extends Configuration {
     private String disabledSecureConnection;
 
     @NotNull
-    private Duration connectTimeout = Duration.seconds(50L);
+    private Duration connectTimeout = Duration.seconds(25L);
 
     @NotNull
     private Duration readTimeout = Duration.seconds(50L);


### PR DESCRIPTION
## WHAT YOU DID
This change updates connectTimeout to use 25 seconds as a default value. It is needed because Jersey client takes 100 seconds to timeout after failing to establish a connection and Nginx cuts this connection after 60 seconds. Reducing from 50 seconds to 25 seconds in connectTimeout causes the timeout to drop from 100 seconds to 50 seconds. readTimeout is not affected by this issue.

I have tested these changes locally.