### PR TITLE
PP-PP-7358 add metadata validator for product create request

### DIFF
--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -39,7 +39,7 @@ public class Product {
     public static final String FIELD_REFERENCE_LABEL = "reference_label";
     public static final String FIELD_REFERENCE_HINT = "reference_hint";
     public static final String FIELD_LANGUAGE = "language";
-    private static final String FIELD_METADATA = "metadata";
+    public static final String FIELD_METADATA = "metadata";
 
     @JsonProperty(FIELD_EXTERNAL_ID)
     private final String externalId;

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -27,11 +27,14 @@ import static uk.gov.pay.products.util.ProductType.ADHOC;
 public class ProductRequestValidator {
     private final RequestValidations requestValidations;
     private final boolean returnUrlMustBeSecure;
+    private final ProductsMetadataRequestValidator metadataRequestValidator;
 
     @Inject
-    public ProductRequestValidator(RequestValidations requestValidations, ProductsConfiguration configuration) {
+    public ProductRequestValidator(RequestValidations requestValidations, ProductsConfiguration configuration,
+                                   ProductsMetadataRequestValidator metadataRequestValidator) {
         this.requestValidations = requestValidations;
         this.returnUrlMustBeSecure = configuration.getReturnUrlMustBeSecure();
+        this.metadataRequestValidator = metadataRequestValidator;
     }
 
     public Optional<Errors> validateCreateRequest(JsonNode payload) {
@@ -73,6 +76,10 @@ public class ProductRequestValidator {
             if (errors.isEmpty()) {
                 errors = requestValidations.checkIsValidEnumValue(payload, EnumSet.allOf(SupportedLanguage.class), FIELD_LANGUAGE);
             }
+        }
+
+        if (errors.isEmpty()) {
+            return metadataRequestValidator.validateCreateProductRequest(payload);
         }
         
         return errors.map(Errors::from);

--- a/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
@@ -5,15 +5,19 @@ import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.products.model.ProductMetadata;
 import uk.gov.pay.products.util.Errors;
 
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static java.util.function.Predicate.isEqual;
 
 public class ProductsMetadataRequestValidator {
 
+    private static final String METADATA_FIELD_NAME = "metadata";
     private static final String MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG = format("Maximum number of allowed metadata [ %s ] exceeded",
             ExternalMetadata.MAX_KEY_VALUE_PAIRS);
     private static final String EMPTY_PAYLOAD_ERROR_MSG = "Empty payload is not allowed";
@@ -21,7 +25,12 @@ public class ProductsMetadataRequestValidator {
     private static final String DUPLICATE_KEY_ERROR_MSG = "Key [ %s ] already exists, duplicate keys not allowed";
     private static final String NON_EXISTENT_KEY_ERROR_MSG = "Key [ %s ] does not exist";
     private static final String MAX_KEY_FIELD_ERROR_MSG = format("Maximum key field length is [ %s ]", ExternalMetadata.MAX_KEY_LENGTH);
-    private static final String MAX_VALUE_FILED_ERROR_MSG = format("Maximum value field length is [ %s ]", ExternalMetadata.MAX_VALUE_LENGTH);
+    private static final String MAX_VALUE_FIELD_ERROR_MSG = format("Maximum value field length is [ %s ]", ExternalMetadata.MAX_VALUE_LENGTH);
+    private static final String MAX_KEY_FIELD_ERROR_MSG_WITH_KEY = "Field [ metadata ] key [ %s ] exceeds allowed length of [ %s ] characters";
+    private static final String MAX_VALUE_FIELD_ERROR_MSG_WITH_VALUE = "Field [ metadata ] value [ %s ] is over maximum field length allowed [ %s ]";
+    private static final String EMPTY_METADATA_KEY_ERROR_MESSAGE = "Field [ metadata ] cannot be empty";
+    private static final String METADATA_KEY_LENGTH_ERROR_MESSAGE = format("Field [ metadata ] key length must be between 1 and %s characters", ExternalMetadata.MAX_KEY_LENGTH);
+    private static final String DUPLICATE_KEY_ERROR_MSG_CREATE_PRODUCT = "Field [ metadata ] with duplicate key [ %s ]";
 
     public Optional<Errors> validateCreateRequest(JsonNode payload, List<ProductMetadata> existingMetadataList) {
         if (existingMetadataList.size() >= ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
@@ -67,7 +76,42 @@ public class ProductsMetadataRequestValidator {
         }
 
         if (payload.get(key).asText().length() > ExternalMetadata.MAX_VALUE_LENGTH) {
-            return Optional.of(Errors.from(MAX_VALUE_FILED_ERROR_MSG, "VALUE_LENGTH_OVER_MAX_SIZE"));
+            return Optional.of(Errors.from(MAX_VALUE_FIELD_ERROR_MSG, "VALUE_LENGTH_OVER_MAX_SIZE"));
+        }
+
+        return Optional.empty();
+    }
+
+    public Optional<Errors> validateCreateProductRequest(JsonNode payload) {
+        JsonNode metadataLoad = payload.get(METADATA_FIELD_NAME);
+        if (metadataLoad == null) {
+            return Optional.empty();
+        }
+        if (metadataLoad.isEmpty()) {
+            return Optional.of(Errors.from(EMPTY_METADATA_KEY_ERROR_MESSAGE, "EMPTY_METADATA_KEY"));
+        }
+
+        if (metadataLoad.size() >= ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
+            return Optional.of(Errors.from(MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG, "MAX_METADATA_LENGTH_EXCEEDED"));
+        }
+
+        Iterator<String> fieldNames = metadataLoad.fieldNames();
+        Set<String> duplicateFieldNames = new HashSet();
+        while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            if (fieldName.length() == 0) {
+                return Optional.of(Errors.from(METADATA_KEY_LENGTH_ERROR_MESSAGE, "EMPTY_METADATA_KEY"));
+            }
+            if (fieldName.length() > ExternalMetadata.MAX_KEY_LENGTH) {
+                return Optional.of(Errors.from(format(MAX_KEY_FIELD_ERROR_MSG_WITH_KEY, fieldName, ExternalMetadata.MAX_KEY_LENGTH), "KEY_LENGTH_OVER_MAX_SIZE"));
+            }
+            String value = metadataLoad.get(fieldName).asText();
+            if (value.length() > ExternalMetadata.MAX_VALUE_LENGTH) {
+                return Optional.of(Errors.from(format(MAX_VALUE_FIELD_ERROR_MSG_WITH_VALUE, value, ExternalMetadata.MAX_VALUE_LENGTH), "VALUE_LENGTH_MAX_SIZE"));
+            }
+            if (!duplicateFieldNames.add(fieldName.toLowerCase())) {
+                return Optional.of(Errors.from(format(DUPLICATE_KEY_ERROR_MSG_CREATE_PRODUCT, fieldName), "DUPLICATE_METADATA_KEYS"));
+            }
         }
 
         return Optional.empty();

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -33,7 +33,7 @@ public class ProductRequestValidatorTest {
     private static final String FIELD_REFERENCE_HINT = "reference_hint";
     private static final String FIELD_LANGUAGE = "language";
 
-    private static final ProductRequestValidator productRequestValidator = new ProductRequestValidator(new RequestValidations(), new ProductsConfiguration());
+    private static final ProductRequestValidator productRequestValidator = new ProductRequestValidator(new RequestValidations(), new ProductsConfiguration(), new ProductsMetadataRequestValidator());
 
     @Test
     public void shouldPass_whenAllFieldsPresent() {

--- a/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.products.model.ProductMetadata;
 import uk.gov.pay.products.util.Errors;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -110,4 +111,70 @@ public class ProductsMetadataRequestValidatorTest {
         assertThat(errors.get().getErrors().get(0).contains("Key [ country ] does not exist"), is(true));
     }
 
+    @Test
+    public void shouldNotErrorOnMissingMetadataObjectForProductCreate() {
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of());
+        Optional<Errors> errors = validator.validateCreateProductRequest(payload);
+        assertThat(errors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldErrorOnTooMuchKeyValuePairsForProductCreate() {
+        Map<String, String> mapToJson = new HashMap<>();
+        for (int count = 1; count < 12; count++) {
+            mapToJson.put("key" + count, "value" + count);
+        }
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("metadata", mapToJson));
+        Optional<Errors> errors = validator.validateCreateProductRequest(payload);
+        assertThat(errors.isPresent(), is(true));
+        List<String> errorList = errors.get().getErrors();
+        assertThat(errorList.size(), is(1));
+        assertThat(errorList.get(0), is("Maximum number of allowed metadata [ " + ExternalMetadata.MAX_KEY_VALUE_PAIRS + " ] exceeded"));
+        JsonNode errorNode = new ObjectMapper().valueToTree(errors.get());
+        assertThat(errorNode.get("error_identifier").asText(), is("MAX_METADATA_LENGTH_EXCEEDED"));
+    }
+
+    @Test
+    public void shouldErrorOnTooLongKeyFieldForProductCreate() {
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("metadata", Map.of(TOO_LONG_KEY, "value")));
+        Optional<Errors> errors = validator.validateCreateProductRequest(payload);
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0), is("Field [ metadata ] key [ " + TOO_LONG_KEY + " ] exceeds allowed length of [ 30 ] characters"));
+        JsonNode errorNode = new ObjectMapper().valueToTree(errors.get());
+        assertThat(errorNode.get("error_identifier").asText(), is("KEY_LENGTH_OVER_MAX_SIZE"));
+    }
+
+    @Test
+    public void shouldErrorOnDuplicateKeysForProductCreate() {
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("metadata", Map.of("key", "value", "Key", "anotherValue")));
+        Optional<Errors> errors = validator.validateCreateProductRequest(payload);
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0).contains("Field [ metadata ] with duplicate key"), is(true));
+        JsonNode errorNode = new ObjectMapper().valueToTree(errors.get());
+        assertThat(errorNode.get("error_identifier").asText(), is("DUPLICATE_METADATA_KEYS"));
+    }
+
+    @Test
+    public void shouldErrorOnTooLongValueFieldForProductCreate() {
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("metadata", Map.of("key", TOO_LONG_VALUE)));
+        Optional<Errors> errors = validator.validateCreateProductRequest(payload);
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0), is("Field [ metadata ] value [ " + TOO_LONG_VALUE + " ] is over maximum field length allowed [ " + ExternalMetadata.MAX_VALUE_LENGTH + " ]"));
+        JsonNode errorNode = new ObjectMapper().valueToTree(errors.get());
+        assertThat(errorNode.get("error_identifier").asText(), is("VALUE_LENGTH_MAX_SIZE"));
+    }
+
+    @Test
+    public void shouldErrorOnEmptyKeyForProductCreate() {
+        JsonNode payload = new ObjectMapper().valueToTree(Map.of("metadata", Map.of("", TOO_LONG_VALUE)));
+        Optional<Errors> errors = validator.validateCreateProductRequest(payload);
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors().get(0), is("Field [ metadata ] key length must be between 1 and 30 characters"));
+        JsonNode errorNode = new ObjectMapper().valueToTree(errors.get());
+        assertThat(errorNode.get("error_identifier").asText(), is("EMPTY_METADATA_KEY"));
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
- add a metadata validator for product create request. this is needed as the requirements slightly differ to when adding metadata for an existing product
- add relevant tests
