### PR TITLE
BAU Don't log errors when 4xx exceptions are thrown

### DIFF
--- a/src/main/java/uk/gov/pay/products/exception/mapper/BadPaymentRequestExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/BadPaymentRequestExceptionMapper.java
@@ -14,7 +14,7 @@ public class BadPaymentRequestExceptionMapper implements ExceptionMapper<BadPaym
 
     @Override
     public Response toResponse(BadPaymentRequestException exception) {
-        logger.error("BadPaymentRequestException thrown.", exception);
+        logger.info("BadPaymentRequestException thrown.", exception);
         return Response
                 .status(Response.Status.BAD_REQUEST)
                 .entity(Errors.from(exception.getMessage()))

--- a/src/main/java/uk/gov/pay/products/exception/mapper/MetadataNotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/MetadataNotFoundExceptionMapper.java
@@ -17,7 +17,7 @@ public class MetadataNotFoundExceptionMapper implements ExceptionMapper<Metadata
 
     @Override
     public Response toResponse(MetadataNotFoundException exception) {
-        logger.error("PaymentCreationException thrown.", exception);
+        logger.info("PaymentCreationException thrown.", exception);
 
         return Response
                 .status(Response.Status.NOT_FOUND)

--- a/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreatorNotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreatorNotFoundExceptionMapper.java
@@ -16,7 +16,7 @@ public class PaymentCreatorNotFoundExceptionMapper implements ExceptionMapper<Pa
 
     @Override
     public Response toResponse(PaymentCreatorNotFoundException exception) {
-        logger.error("PaymentCreatorNotFoundException thrown.", exception);
+        logger.info("PaymentCreatorNotFoundException thrown.", exception);
         return Response
                 .status(Response.Status.NOT_FOUND)
                 .entity(Errors.from(format("Product with product id %s not found.", exception.getProductExternalId())))

--- a/src/main/java/uk/gov/pay/products/exception/mapper/ProductNotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/ProductNotFoundExceptionMapper.java
@@ -14,7 +14,7 @@ public class ProductNotFoundExceptionMapper implements ExceptionMapper<ProductNo
     private final Logger logger = LoggerFactory.getLogger(getClass());
     @Override
     public Response toResponse(ProductNotFoundException exception) {
-        logger.error("PaymentCreatorNotFoundException thrown", exception);
+        logger.info("PaymentCreatorNotFoundException thrown", exception);
         return Response
                 .status(Response.Status.NOT_FOUND)
                 .entity(Errors.from(format("Product with product id %s not found.", exception.getProductExternalId())))


### PR DESCRIPTION
For exceptions that are mapped to a 4xx response don't log an error so they aren't reported in Sentry
