### PR TITLE
PP-7709 Allow products to be retrieved by account ID and type

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -34,7 +34,7 @@ Content-Type: application/json
 | `gateway_account_id`     |    X     | gateway account id of the Gateway Account as identified by adminusers.  |   |
 | `pay_api_token`          |    X     | valid api token for the gateway account of above service which this product takes payments for |  |
 | `name`                   |    X     | Name of the product. This will be passed as the `name` when creating the charge | |
-| `price`                  |          | Price for the product in pence. This will be passed as the  `amount` when creating charge. Mandatory for Non-ADHOC products    | |
+| `price`                  |          | Price for the product in pence. This will be passed as the  `amount` when creating charge. Mandatory for Non-ADHOC and Non-AGENT_INITIATED_MOTO products    | |
 | `description`            |          | Description of the product. This will be passed as the `description` when creating the charge | |
 | `return_url`             |          | (https only) where to redirect to upon completion of a payment. If not provided, `pay-products` will generate a default url to itself when creating a charge | |
 | `service_name_path`      |          | Service Name Path part of Product Path. Required for Adhoc type only.  |   |
@@ -122,7 +122,7 @@ Content-Type: application/json
 | Field                    | required | Description                                                      | Supported Values     |
 | ------------------------ |:--------:| ---------------------------------------------------------------- |----------------------|
 | `name`                   |    X     | Name of the product. This will be passed as the `name` when creating the charge | |
-| `price`                  |    X     | Price for the product in pence. This will be passed as the  `amount` when creating charge. Mandatory for Non-ADHOC products    | |
+| `price`                  |    X     | Price for the product in pence. This will be passed as the  `amount` when creating charge. Mandatory for Non-ADHOC and Non-AGENT_INITIATED_MOTO products    | |
 | `description`            |          | Description of the product. This will be passed as the `description` when creating the charge | |
 
 ### Response example
@@ -291,10 +291,14 @@ same as above(docs/api_specification.md#post-v1apiproducts) except that `_links.
 
 ## GET /v1/api/gateway-account/{gatewayAccountId}/products
 
-This endpoint retrieves list of products that belongs to the specified gatewayAccountId.
+This endpoint retrieves list of products that belongs to the specified gatewayAccountId, optionally filtering by type (ADHOC, PROTOTYPE etc.).
 
 ```
 GET /v1/api/gateway-account/1234/products
+```  
+
+```
+GET /v1/api/gateway-account/1234/products?type=ADHOC
 ```  
 
 ### Response example

--- a/src/main/java/uk/gov/pay/products/persistence/dao/ProductDao.java
+++ b/src/main/java/uk/gov/pay/products/persistence/dao/ProductDao.java
@@ -63,6 +63,20 @@ public class ProductDao extends JpaDao<ProductEntity> {
                 .getResultList();
     }
 
+    public List<ProductEntity> findByGatewayAccountIdAndType(Integer gatewayAccountId, ProductType type) {
+        String query = "SELECT product FROM ProductEntity product " +
+                "WHERE product.gatewayAccountId = :gatewayAccountId " +
+                "AND product.type = :type " +
+                "AND product.status = :status";
+
+        return entityManager.get()
+                .createQuery(query, ProductEntity.class)
+                .setParameter("gatewayAccountId", gatewayAccountId)
+                .setParameter("type", type)
+                .setParameter("status", ProductStatus.ACTIVE)
+                .getResultList();
+    }
+
     public Optional<ProductEntity> findByProductPath(String serviceNamePath, String productNamePath) {
         String query = "SELECT product FROM ProductEntity product " +
                 "WHERE product.serviceNamePath = :serviceNamePath " +

--- a/src/main/java/uk/gov/pay/products/service/ProductFinder.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductFinder.java
@@ -7,6 +7,7 @@ import uk.gov.pay.products.model.ProductUsageStat;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
 import uk.gov.pay.products.util.ProductStatus;
+import uk.gov.pay.products.util.ProductType;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,13 +26,15 @@ public class ProductFinder {
     @Transactional
     public Optional<Product> findByExternalId(String externalId) {
         return productDao.findByExternalId(externalId)
-                .map(productEntity -> linksDecorator.decorate(productEntity.toProduct()));
+                .map(ProductEntity::toProduct)
+                .map(linksDecorator::decorate);
     }
 
     @Transactional
     public Optional<Product> findByGatewayAccountIdAndExternalId(Integer gatewayAccountId, String externalId) {
         return productDao.findByGatewayAccountIdAndExternalId(gatewayAccountId, externalId)
-                .map(productEntity -> linksDecorator.decorate(productEntity.toProduct()));
+                .map(ProductEntity::toProduct)
+                .map(linksDecorator::decorate);
     }
 
     @Deprecated
@@ -92,26 +95,31 @@ public class ProductFinder {
         return productDao.findByGatewayAccountId(gatewayAccountId)
                 .stream()
                 .map(ProductEntity::toProduct)
-                .collect(Collectors.toList())
-                .stream()
                 .map(linksDecorator::decorate)
-                .collect(Collectors.toList());
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Transactional
+    public List<Product> findByGatewayAccountIdAndType(Integer gatewayAccountId, ProductType type) {
+        return productDao.findByGatewayAccountIdAndType(gatewayAccountId, type)
+                .stream()
+                .map(ProductEntity::toProduct)
+                .map(linksDecorator::decorate)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Transactional
     public Optional<Product> findByProductPath(String serviceNamePath, String productNamePath) {
         return productDao.findByProductPath(serviceNamePath, productNamePath)
-                .map(productEntity -> linksDecorator.decorate(productEntity.toProduct()));
+                .map(ProductEntity::toProduct)
+                .map(linksDecorator::decorate);
     }
 
     @Transactional
     public List<ProductUsageStat> findProductsAndUsage(Integer gatewayAccountId) {
         return productDao.findProductsAndUsage(gatewayAccountId)
                 .stream()
-                .map(productUsageStat -> {
-                    productUsageStat.setProduct(linksDecorator.decorate(productUsageStat.getProduct()));
-                    return productUsageStat;
-                })
-                .collect(Collectors.toList());
+                .peek(productUsageStat -> productUsageStat.setProduct(linksDecorator.decorate(productUsageStat.getProduct())))
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductRequestValidator.java
@@ -26,6 +26,7 @@ import static uk.gov.pay.products.util.ProductType.ADHOC;
 import static uk.gov.pay.products.util.ProductType.AGENT_INITIATED_MOTO;
 
 public class ProductRequestValidator {
+
     private final RequestValidations requestValidations;
     private final boolean returnUrlMustBeSecure;
     private final ProductsMetadataRequestValidator metadataRequestValidator;
@@ -99,6 +100,15 @@ public class ProductRequestValidator {
         if (errors.isEmpty()) {
             return metadataRequestValidator.validateMetadata(payload);
         }
+
+        return errors.map(Errors::from);
+    }
+
+    public Optional<Errors> validateProductType(String type) {
+        Optional<List<String>> errors = requestValidations.checkIsValidEnumValue (
+                type,
+                EnumSet.allOf(ProductType.class),
+                FIELD_TYPE);
 
         return errors.map(Errors::from);
     }

--- a/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
@@ -45,8 +45,11 @@ public class RequestValidations {
     }
 
     Optional<List<String>> checkIsValidEnumValue(JsonNode payload, EnumSet<?> enumSet, String field) {
-        String value = payload.get(field).asText();
-        if (enumSet.stream().noneMatch(constant -> constant.toString().equals(value))) {
+        return checkIsValidEnumValue(payload.get(field).asText(), enumSet, field);
+    }
+
+    Optional<List<String>> checkIsValidEnumValue(String value, EnumSet<?> enumSet, String field) {
+        if (enumSet.stream().map(Enum::toString).noneMatch(constant -> constant.equals(value))) {
             return Optional.of(singletonList(format("Field [%s] must be one of %s", field, enumSet)));
         }
         return Optional.empty();

--- a/src/test/java/uk/gov/pay/products/persistence/dao/ProductDaoIT.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/ProductDaoIT.java
@@ -21,10 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
@@ -137,6 +137,42 @@ public class ProductDaoIT extends DaoTestBase {
         List<ProductEntity> products = productDao.findByGatewayAccountId(gatewayAccountId);
         assertThat(products.size(), is(1));
         assertThat(products.get(0).toProduct(), ProductMatcher.isSame(activeProduct));
+    }
+
+    @Test
+    public void findByGatewayAccountIdAndType_shouldReturnActiveProductsOfTheGivenTypeForTheGivenAccount() {
+        String externalId = randomUuid();
+        Integer gatewayAccountId = randomInt();
+
+        Product activeProductWithCorrectType = ProductEntityFixture.aProductEntity()
+                .withExternalId(externalId)
+                .withGatewayAccountId(gatewayAccountId)
+                .withType(ProductType.ADHOC)
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(activeProductWithCorrectType);
+
+        Product activeProductWithIncorrectType = ProductEntityFixture.aProductEntity()
+                .withGatewayAccountId(gatewayAccountId)
+                .withType(ProductType.DEMO)
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(activeProductWithIncorrectType);
+
+        Product inactiveProductWithCorrectType = ProductEntityFixture.aProductEntity()
+                .withGatewayAccountId(gatewayAccountId)
+                .withStatus(ProductStatus.INACTIVE)
+                .withType(ProductType.ADHOC)
+                .build()
+                .toProduct();
+
+        databaseHelper.addProduct(inactiveProductWithCorrectType);
+
+        List<ProductEntity> products = productDao.findByGatewayAccountIdAndType(gatewayAccountId, ProductType.ADHOC);
+        assertThat(products.size(), is(1));
+        assertThat(products.get(0).toProduct(), ProductMatcher.isSame(activeProductWithCorrectType));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
+++ b/src/test/java/uk/gov/pay/products/service/ProductFinderTest.java
@@ -9,10 +9,13 @@ import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
 import uk.gov.pay.products.util.ProductStatus;
+import uk.gov.pay.products.util.ProductType;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -54,6 +57,41 @@ public class ProductFinderTest {
         Optional<Product> productOptional = productFinder.findByExternalId(externalId);
 
         assertFalse(productOptional.isPresent());
+    }
+
+    @Test
+    public void findByGatewayAccountId_shouldReturnDecoratedProduct_whenFound() {
+        Integer gatewayAccountId = 1;
+        String externalId = "1";
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setExternalId(externalId);
+        productEntity.setGatewayAccountId(gatewayAccountId);
+        productEntity.setReferenceEnabled(false);
+        when(productDao.findByGatewayAccountId(gatewayAccountId)).thenReturn(List.of(productEntity));
+
+        List<Product> productsList = productFinder.findByGatewayAccountId(gatewayAccountId);
+
+        assertThat(productsList.size(), is(1));
+        assertThat(productsList.get(0).getExternalId(), is(externalId));
+        assertThat(productsList.get(0).getLinks().size(), is(2));
+    }
+
+    @Test
+    public void findByGatewayAccountIdAndType_shouldReturnDecoratedProduct_whenFound() {
+        Integer gatewayAccountId = 1;
+        String externalId = "1";
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setExternalId(externalId);
+        productEntity.setGatewayAccountId(gatewayAccountId);
+        productEntity.setType(ProductType.ADHOC);
+        productEntity.setReferenceEnabled(false);
+        when(productDao.findByGatewayAccountIdAndType(gatewayAccountId, ProductType.ADHOC)).thenReturn(List.of(productEntity));
+
+        List<Product> productsList = productFinder.findByGatewayAccountIdAndType(gatewayAccountId, ProductType.ADHOC);
+
+        assertThat(productsList.size(), is(1));
+        assertThat(productsList.get(0).getExternalId(), is(externalId));
+        assertThat(productsList.get(0).getLinks().size(), is(greaterThan(0)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductRequestValidatorTest.java
@@ -472,4 +472,13 @@ public class ProductRequestValidatorTest {
 
         assertThat(errors.isPresent(), is(false));
     }
+
+    @Test
+    public void shouldError_whenTypeIsInvalid() {
+        Optional<Errors> errors = productRequestValidator.validateProductType("THIS_IS_NOT_A_PRODUCT_TYPE");
+
+        assertThat(errors.isPresent(), is(true));
+        assertThat(errors.get().getErrors().toString(), is("[Field [type] must be one of [DEMO, PROTOTYPE, ADHOC, AGENT_INITIATED_MOTO]]"));
+    }
+
 }


### PR DESCRIPTION
Enhance the `/gateway-account/{gatewayAccountId}/products` endpoint so that it takes an optional `type` parameter with a single value like `ADHOC` or `PROTOTYPE` and filters the results appropriately.