### PR TITLE
BAU Add dropwizard-json-logging dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>3.10.1</version>


### PR DESCRIPTION
pay-java-commons has a dependency on dropwizard-json-logging. Because pay-java-commons uses its own version of dropwizard, the pay-java-commons version and dropwizard dependency versions for the app need to be updated at the same time to build successfully.

Add a direct dependency on dropwizard-json-logging so we ignore the version in pay-java-commons and use the version consistent with all the other dropwizard modules.