### PR TITLE
PP-8415 Detect and log PAN in reference field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.20</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.7</version>
+        </dependency>
+
 
         <!-- testing -->
         <dependency>

--- a/src/main/java/uk/gov/pay/products/validations/PanDetector.java
+++ b/src/main/java/uk/gov/pay/products/validations/PanDetector.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.products.validations;
+
+import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
+
+public class PanDetector {
+    private static final int MIN_PAN_LENGTH = 12;
+    private static final int MAX_PAN_LENGTH = 19;
+    
+    public static boolean isSuspectedPan(String reference) {
+        if (reference.length() < MIN_PAN_LENGTH || reference.length() > MAX_PAN_LENGTH) {
+            return false;
+        }
+        var cleaned = reference
+                .replace("-", "")
+                .replace(" ", "");
+
+        return (new LuhnCheckDigit()).isValid(cleaned);
+    }
+}

--- a/src/test/java/uk/gov/pay/products/validations/PanDetectorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/PanDetectorTest.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.products.validations;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PanDetectorTest {
+    @Test
+    public void shouldDetectPotentialPAN() {
+        assertTrue(PanDetector.isSuspectedPan("4242424242424242"));
+    }
+
+    @Test
+    public void shouldDetectPotentialPAN_whenDigitsAreSeparatedByHyphens() {
+        assertTrue(PanDetector.isSuspectedPan("42424242-42424242"));
+    }
+    
+    @Test
+    public void shouldDetectPotentialPAN_whenDigitsAreSeparatedBySpaces() {
+        assertTrue(PanDetector.isSuspectedPan("424242424 2424242"));
+    }
+
+    @Test
+    public void shouldNotDetectPotentialPAN_whenNumberIsShorterThan12Digits() {
+        assertFalse(PanDetector.isSuspectedPan("42424242424"));
+    }
+
+    @Test
+    public void shouldNotDetectPotentialPAN_whenNumberIsLongerThan19Digits() {
+        assertFalse(PanDetector.isSuspectedPan("42424242424242424242"));
+    }
+    
+    @Test
+    public void shouldNotDetectPotentialPAN_whenNumberDoesNotPassLuhnAlgorithm() {
+        assertFalse(PanDetector.isSuspectedPan("1111111111111111"));
+    }
+}


### PR DESCRIPTION
Log when we see suspected PAN in reference field. This will enable us to remove `reference` from logs whilst still catching the case when users do this. Products does not log the reference field at all, but once we have this in place can remove the logging from publicapi and connector.

I have chosen to implement this in a separate class to make it easily testable. I have put it in the validator package which is a bit loose, but seems best place for it (happy to discuss this). 

For the actual criteria for "looking like a PAN" I have copied and improved on what we do in frontend [here](https://github.com/alphagov/pay-frontend/blob/437a67cb8c50a9368bb767d9c6b2ca5ce4dee784/app/utils/charge-validation-fields.js#L145) and [here](https://github.com/alphagov/pay-frontend/blob/437a67cb8c50a9368bb767d9c6b2ca5ce4dee784/app/utils/charge-validation-fields.js#L145) - length between 12 and 19 inclusive, Luhn valid. 