### PR TITLE
PP-8551 Rationalise product update request

### DIFF
--- a/src/main/java/uk/gov/pay/products/model/ProductMetadata.java
+++ b/src/main/java/uk/gov/pay/products/model/ProductMetadata.java
@@ -6,24 +6,18 @@ import uk.gov.pay.products.persistence.entity.ProductMetadataEntity;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ProductMetadata {
 
-    @JsonIgnore
-    private Integer productId;
     @JsonIgnore
     private String key;
     @JsonIgnore
     private String value;
 
-    public ProductMetadata(Integer productId, String key, String value) {
-        this.productId = productId;
+    public ProductMetadata(String key, String value) {
         this.key = key;
         this.value = value;
-    }
-
-    public Integer getProductId() {
-        return productId;
     }
 
     public String getKey() {
@@ -35,11 +29,11 @@ public class ProductMetadata {
     }
 
     public static ProductMetadata from(ProductMetadataEntity productMetadataEntity) {
-        return new ProductMetadata(productMetadataEntity.getProductEntity().getId(), 
-                productMetadataEntity.getMetadataKey(), 
+        return new ProductMetadata(
+                productMetadataEntity.getMetadataKey(),
                 productMetadataEntity.getMetadataValue());
     }
-
+    
     @JsonValue()
     public Map<String, String> getKvPair() {
         Map<String, String> map = new HashMap<>();
@@ -50,5 +44,18 @@ public class ProductMetadata {
     @Override
     public String toString() {
         return "key= " + key + " value= " + value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProductMetadata that = (ProductMetadata) o;
+        return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
     }
 }

--- a/src/main/java/uk/gov/pay/products/model/ProductUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/products/model/ProductUpdateRequest.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.products.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+import static uk.gov.pay.products.util.MetadataDeserializer.extractMetadata;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ProductUpdateRequest {
+
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_PRICE = "price";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_REFERENCE_ENABLED = "reference_enabled";
+    public static final String FIELD_REFERENCE_LABEL = "reference_label";
+    public static final String FIELD_REFERENCE_HINT = "reference_hint";
+    public static final String FIELD_METADATA = "metadata";
+
+    private String name;
+    private String description;
+    private Long price;
+    private Boolean referenceEnabled;
+    private String referenceLabel;
+    private String referenceHint;
+    private List<ProductMetadata> metadata;
+
+    public ProductUpdateRequest(
+            String name,
+            String description,
+            Long price,
+            Boolean referenceEnabled,
+            String referenceLabel,
+            String referenceHint,
+            List<ProductMetadata> metadata) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.referenceEnabled = referenceEnabled;
+        this.referenceLabel = referenceLabel;
+        this.referenceHint = referenceHint;
+        this.metadata = metadata;
+    }
+
+    public static ProductUpdateRequest from(JsonNode jsonPayload) {
+        String name = (jsonPayload.get(FIELD_NAME) != null) ? jsonPayload.get(FIELD_NAME).asText() : null;
+        Long price = (jsonPayload.get(FIELD_PRICE) != null) ? jsonPayload.get(FIELD_PRICE).asLong() : null;
+        String description = (jsonPayload.get(FIELD_DESCRIPTION) != null) ? jsonPayload.get(FIELD_DESCRIPTION).asText() : null;
+        Boolean referenceEnabled = (jsonPayload.get(FIELD_REFERENCE_ENABLED) != null) && jsonPayload.get(FIELD_REFERENCE_ENABLED).asBoolean();
+        String referenceLabel = (jsonPayload.get(FIELD_REFERENCE_LABEL) != null) ? jsonPayload.get(FIELD_REFERENCE_LABEL).asText() : null;
+        String referenceHint = (jsonPayload.get(FIELD_REFERENCE_HINT) != null) ? jsonPayload.get(FIELD_REFERENCE_HINT).asText() : null;
+        List<ProductMetadata> metadataList = extractMetadata(jsonPayload, FIELD_METADATA);
+
+        return new ProductUpdateRequest(name, description, price, referenceEnabled, referenceLabel, referenceHint, metadataList);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public Boolean getReferenceEnabled() {
+        return referenceEnabled;
+    }
+
+    public String getReferenceLabel() {
+        return referenceLabel;
+    }
+
+    public String getReferenceHint() {
+        return referenceHint;
+    }
+
+    public List<ProductMetadata> getMetadata() {
+        return metadata;
+    }
+}

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductMetadataEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductMetadataEntity.java
@@ -60,7 +60,7 @@ public class ProductMetadataEntity extends AbstractEntity {
     }
 
     public ProductMetadata toMetadata() {
-        return new ProductMetadata(this.getId(), this.metadataKey, this.metadataValue);
+        return new ProductMetadata(this.metadataKey, this.metadataValue);
     }
 
     public static ProductMetadataEntity from(ProductEntity productEntity, ProductMetadata metadata) {

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.products.model.Product;
 import uk.gov.pay.products.model.ProductUsageStat;
+import uk.gov.pay.products.model.ProductUpdateRequest;
 import uk.gov.pay.products.service.ProductApiTokenManager;
 import uk.gov.pay.products.service.ProductFactory;
 import uk.gov.pay.products.util.ProductType;
@@ -150,7 +151,7 @@ public class ProductResource {
         return requestValidator.validateUpdateRequest(payload)
                 .map(errors -> Response.status(Status.BAD_REQUEST).entity(errors).build())
                 .orElseGet(() ->
-                    productFactory.productCreator().doUpdateByGatewayAccountId(gatewayAccountId, productExternalId, Product.from(payload))
+                    productFactory.productCreator().doUpdateByGatewayAccountId(gatewayAccountId, productExternalId, ProductUpdateRequest.from(payload))
                             .map(product -> Response.status(OK).entity(product).build())
                             .orElseGet(() -> Response.status(NOT_FOUND).build()));
     }

--- a/src/main/java/uk/gov/pay/products/service/ProductCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/ProductCreator.java
@@ -3,6 +3,7 @@ package uk.gov.pay.products.service;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.products.model.Product;
+import uk.gov.pay.products.model.ProductUpdateRequest;
 import uk.gov.pay.products.persistence.dao.ProductDao;
 import uk.gov.pay.products.persistence.dao.ProductMetadataDao;
 import uk.gov.pay.products.persistence.entity.ProductEntity;
@@ -38,17 +39,17 @@ public class ProductCreator {
     }
 
     @Transactional
-    public Optional<Product> doUpdateByGatewayAccountId(Integer gatewayAccountId, String productExternalId, Product product) {
+    public Optional<Product> doUpdateByGatewayAccountId(Integer gatewayAccountId, String productExternalId, ProductUpdateRequest productUpdateRequest) {
 
         Optional<ProductEntity> productEntityUpdated = productDao
                 .findByGatewayAccountIdAndExternalId(gatewayAccountId, productExternalId)
                 .map(productEntity -> {
-                    productEntity.setName(product.getName());
-                    productEntity.setDescription(product.getDescription());
-                    productEntity.setPrice(product.getPrice());
-                    productEntity.setReferenceEnabled(product.getReferenceEnabled());
-                    productEntity.setReferenceLabel(product.getReferenceLabel());
-                    productEntity.setReferenceHint(product.getReferenceHint());
+                    productEntity.setName(productUpdateRequest.getName());
+                    productEntity.setDescription(productUpdateRequest.getDescription());
+                    productEntity.setPrice(productUpdateRequest.getPrice());
+                    productEntity.setReferenceEnabled(productUpdateRequest.getReferenceEnabled());
+                    productEntity.setReferenceLabel(productUpdateRequest.getReferenceLabel());
+                    productEntity.setReferenceHint(productUpdateRequest.getReferenceHint());
 
                     return productEntity;
                 });
@@ -56,8 +57,8 @@ public class ProductCreator {
         productMetadataDao.deleteForProductExternalId(productExternalId);
 
         productEntityUpdated.ifPresent(productEntity -> {
-            if (product.getMetadata() != null && !product.getMetadata().isEmpty()) {
-                List<ProductMetadataEntity> productMetadataEntities = product.getMetadata()
+            if (productUpdateRequest.getMetadata() != null && !productUpdateRequest.getMetadata().isEmpty()) {
+                List<ProductMetadataEntity> productMetadataEntities = productUpdateRequest.getMetadata()
                         .stream()
                         .map(productMetadata -> ProductMetadataEntity.from(productEntity, productMetadata))
                         .collect(Collectors.toList());

--- a/src/main/java/uk/gov/pay/products/util/MetadataDeserializer.java
+++ b/src/main/java/uk/gov/pay/products/util/MetadataDeserializer.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.products.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.pay.products.model.ProductMetadata;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class MetadataDeserializer {
+    
+    public static List<ProductMetadata> extractMetadata(JsonNode payload, String fieldName) {
+        List<ProductMetadata> metadataList = new ArrayList<>();
+        JsonNode metadata = payload.get(fieldName);
+        if (metadata != null && !metadata.isEmpty()) {
+            Iterator<String> fieldNames = metadata.fieldNames();
+            while (fieldNames.hasNext()) {
+                String key = fieldNames.next();
+                String value = metadata.get(key).textValue();
+                metadataList.add(new ProductMetadata(key, value));
+            }
+        }
+        return metadataList.isEmpty() ? null : metadataList;
+    }
+
+}

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
@@ -460,6 +460,7 @@ public class ProductResourceIT extends IntegrationTest {
                 .withPrice(500)
                 .withGatewayAccountId(gatewayAccountId)
                 .withProductPath("service-name-path" + externalId, "product-name-path" + externalId)
+                .withRequireCaptcha(false)
                 .build()
                 .toProduct();
 
@@ -492,7 +493,8 @@ public class ProductResourceIT extends IntegrationTest {
                 .body(TYPE, is(existingProduct.getType().name()))
                 .body(GATEWAY_ACCOUNT_ID, is(gatewayAccountId))
                 .body(RETURN_URL, is(existingProduct.getReturnUrl()))
-                .body(LANGUAGE, is("en"));
+                .body(LANGUAGE, is("en"))
+                .body(REQUIRE_CAPTCHA, is(false));
 
         String productsUrl = "https://products.url/v1/api/products/";
         String productsUIPayUrl = "https://products-ui.url/pay/";


### PR DESCRIPTION
We were deserializing the product update request to a Product object and then only picking certain fields off that to update which was very confusing.

Rationalise this by deserializing to a new ProductUpdateRequest object that only contains the fields that can be updated by the PATCH request.

Not using Jackson deserialization at this time as that would require unpicking of more things, such as the validations.