### PR TITLE
PP-9010 Upgrade log4j-core and log4j-api to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,18 @@
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
         </dependency>
+        <!-- We do not use log4j-core or log4j-api but some dependencies do
+             and versions before 2.15.0 are vulnerable to CVE-2021-44228 -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.15.0</version>
+        </dependency>
 
 
         <!-- testing -->


### PR DESCRIPTION
Upgrade log4j-core and log4j-api (which we do not use it directly but some
dependencies do) to version 2.15.0 to fix CVE-2021-44228.

## WHAT YOU DID
```
gds5062-2:pay-products danworth$ mvn dependency:tree -Dincludes="*log4j:log4j*"
[INFO] Scanning for projects...
[WARNING] The project uk.gov.pay:pay-products:jar:1.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[INFO]
[INFO] ----------------------< uk.gov.pay:pay-products >-----------------------
[INFO] Building pay-products 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ pay-products ---
[INFO] uk.gov.pay:pay-products:jar:1.0-SNAPSHOT
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] \- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
```