### PR TITLE
bau: Use 'test-fargate' when running provider contract test

### DIFF
--- a/src/test/java/uk/gov/pay/products/pact/ProductsUIContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/ProductsUIContractTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("products")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"products-ui"})
 public class ProductsUIContractTest extends ContractTest {

--- a/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/products/pact/SelfServiceContractTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(PactRunner.class)
 @Provider("products")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test-fargate"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 @IgnoreNoPactsToVerify


### PR DESCRIPTION
The purpose of running the provider contract test is to ensure the app can be
deployed to the test environment without breaking its contractual obligations
with other apps. Pacts are tagged with 'test-fargate' in the concourse deploy
pipeline for app deployments so this tag needs to be updated.