### PR TITLE
PP-9093 Remove explicit dependency on log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,19 +160,6 @@
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
         </dependency>
-        <!-- We do not use log4j-core or log4j-api but some dependencies do
-             and versions before 2.15.0 are vulnerable to CVE-2021-44228 -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-
 
         <!-- testing -->
         <dependency>


### PR DESCRIPTION
We don't bring in log4j transitively so can safely remove the explicit
dependency.