### PR TITLE
PP-9379: Add products as provider pact test reusable workflow

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -1,0 +1,61 @@
+name: Products As Provider Pact Tests
+
+on:
+  workflow_call:
+    inputs:
+      consumer:
+        description: Name of the consumer app, e.g. products-ui
+        required: true
+        type: string
+      consumer_tag:
+        description: Consumer tag. This could be branch name ('master'), PR number ('1234') or deploy tag ('test-fargate')
+        required: true
+        type: string
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
+
+permissions:
+  contents: read
+
+
+jobs:
+  run-products-as-provider-tests:
+    name: Run Products as Provider
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          repository: alphagov/pay-products
+      - name: Set up JDK 11
+        uses: actions/setup-java@f69f00b5e5324696b07f6b1c92f0470a6df00780
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Pull docker image dependencies
+        run: |
+          docker pull govukpay/postgres:11.1
+      - name: Run provider pact tests
+        run: |
+          consumer_tag="${{ inputs.consumer_tag }}"
+          provider_version="${{ github.sha }}"
+          export MAVEN_REPO="$HOME/.m2"
+          mvn test \
+          --batch-mode \
+          -DrunContractTests \
+          -DCONSUMER="$consumer" \
+          -DPACT_CONSUMER_TAG="$consumer_tag" \
+          -Dpact.provider.version="$provider_version" \
+          -Dpact.verifier.publishResults=true \
+          -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
+          -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \
+          -DPACT_BROKER_PASSWORD="${{ secrets.pact_broker_password }}"


### PR DESCRIPTION
## WHAT YOU DID
Add reusable workflow for products-as-provider pact tests. This is the same code as in adminusers, connector, and ledger but for products

## How to test

- See the test workflow in frontend https://github.com/alphagov/pay-frontend/runs/5536224723?check_suite_focus=true (this sets the consumer as products-ui, not frontend, but frontend is the only repo set up so far to be able to execute these and with the pact secrets)

## Code review checklist

### Logging

N/A

### Documentation

N/A