### PR TITLE
PP-8973 Add flag to enable new payment link journey to products

### DIFF
--- a/src/main/resources/migrations/00040_add_column_new_payment_link_journey_enabled_to_products.sql
+++ b/src/main/resources/migrations/00040_add_column_new_payment_link_journey_enabled_to_products.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:add_column_new_payment_link_journey_enabled_to_products
+ALTER TABLE products ADD COLUMN new_payment_link_journey_enabled BOOLEAN DEFAULT false NOT NULL;
+
+--rollback alter table products drop column new_payment_link_journey_enabled;


### PR DESCRIPTION
Add new_payment_link_journey enabled flag to products table. This will be used for enabling the new journey for individual payment links for testing purposes before it is released for all payment links.