### PR TITLE
BAU: Fix Pact Provider version SHA

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           repository: alphagov/pay-products
+      - name: Get Provider SHA
+        id: get-provider-sha
+        run: |
+          echo ::set-output name=provider-sha::$(git rev-parse HEAD)
       - name: Set up JDK 11
         uses: actions/setup-java@f69f00b5e5324696b07f6b1c92f0470a6df00780
         with:
@@ -52,7 +56,7 @@ jobs:
           -DrunContractTests \
           -DCONSUMER="${{ inputs.consumer }}" \
           -DPACT_CONSUMER_TAG="${{ inputs.consumer_tag }}" \
-          -Dpact.provider.version="${{ github.sha }}" \
+          -Dpact.provider.version="${{ steps.get-provider-sha.outputs.provider-sha }}" \
           -Dpact.verifier.publishResults=true \
           -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
           -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \


### PR DESCRIPTION
Ensures this reusable workflow takes the HEAD commit of this repo as the provider SHA, rather than the repo calling this workflow.

See equivalent PR for adminusers: https://github.com/alphagov/pay-adminusers/pull/1291