### PR TITLE
PP-9587 Pass on 403 status from Public api

### DIFF
--- a/src/main/java/uk/gov/pay/products/exception/PaymentCreationException.java
+++ b/src/main/java/uk/gov/pay/products/exception/PaymentCreationException.java
@@ -3,12 +3,18 @@ package uk.gov.pay.products.exception;
 public class PaymentCreationException extends RuntimeException {
 
     private final String productExternalId;
+    private final int errorStatusCode;
 
-    public PaymentCreationException(String productExternalId) {
+    public PaymentCreationException(String productExternalId, int errorStatusCode) {
         this.productExternalId = productExternalId;
+        this.errorStatusCode = errorStatusCode;
     }
 
     public String getProductExternalId() {
         return productExternalId;
+    }
+
+    public int getErrorStatusCode() {
+        return errorStatusCode;
     }
 }

--- a/src/main/java/uk/gov/pay/products/exception/PublicApiResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/products/exception/PublicApiResponseErrorException.java
@@ -20,6 +20,7 @@ public class PublicApiResponseErrorException extends RuntimeException {
         response.close();
     }
 
+
     public PublicApiResponseErrorException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
@@ -8,6 +8,9 @@ import uk.gov.pay.products.util.Errors;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
 public class PaymentCreationExceptionMapper implements ExceptionMapper<PaymentCreationException> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -17,8 +20,10 @@ public class PaymentCreationExceptionMapper implements ExceptionMapper<PaymentCr
     public Response toResponse(PaymentCreationException exception) {
         logger.error("PaymentCreationException thrown.", exception);
 
+        var status = exception.getErrorStatusCode() == FORBIDDEN.getStatusCode()? FORBIDDEN : INTERNAL_SERVER_ERROR;
+        
         return Response
-                .status(Response.Status.INTERNAL_SERVER_ERROR)
+                .status(status)
                 .entity(Errors.from("Downstream system error."))
                 .build();
     }

--- a/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
@@ -12,6 +12,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -48,6 +49,9 @@ public class PaymentEntity extends AbstractEntity {
 
     @Column(name = "reference_number")
     private String referenceNumber;
+    
+    @Transient
+    private int errorStatusCode;
 
     public PaymentEntity() {
     }
@@ -103,6 +107,14 @@ public class PaymentEntity extends AbstractEntity {
     public PaymentStatus getStatus() { return status; }
 
     public void setStatus(PaymentStatus status) { this.status = status; }
+
+    public int getErrorStatusCode() {
+        return errorStatusCode;
+    }
+
+    public void setErrorStatusCode(int errorStatusCode) {
+        this.errorStatusCode = errorStatusCode;
+    }
 
     public Payment toPayment() {
         Payment payment = new Payment(

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -67,7 +67,7 @@ public class PaymentCreator {
                 .complete().get(PaymentEntity.class);
 
         if (paymentEntity.getStatus() == PaymentStatus.ERROR) {
-            throw new PaymentCreationException(paymentEntity.getProductEntity().getExternalId());
+            throw new PaymentCreationException(paymentEntity.getProductEntity().getExternalId(), paymentEntity.getErrorStatusCode());
         }
         return linksDecorator.decorate(paymentEntity.toPayment());
     }
@@ -152,8 +152,9 @@ public class PaymentCreator {
                     );
                 }
             } catch (PublicApiResponseErrorException e) {
-                logger.error("Payment creation for product external id {} failed {}", paymentEntity.getProductEntity().getExternalId(), e);
+                logger.error("Payment creation for product external id {} failed {}", paymentEntity.getProductEntity().getExternalId(), e.getMessage());
                 paymentEntity.setStatus(PaymentStatus.ERROR);
+                paymentEntity.setErrorStatusCode(e.getErrorStatus());
             }
 
             return paymentEntity;

--- a/src/test/java/uk/gov/pay/products/resources/PaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/PaymentResourceIT.java
@@ -265,7 +265,7 @@ public class PaymentResourceIT extends IntegrationTest {
     }
 
     @Test
-    public void createAPayment_shouldReturn500_whenPublicApiReturnsAccountNotLinked() {
+    public void createAPayment_shouldReturn403_whenPublicApiReturnsAccountNotLinked() {
         Product product = aProductEntity()
                 .withExternalId(randomUuid())
                 .withGatewayAccountId(0)
@@ -280,7 +280,7 @@ public class PaymentResourceIT extends IntegrationTest {
                 .accept(APPLICATION_JSON)
                 .post(format("/v1/api/products/%s/payments", product.getExternalId()))
                 .then()
-                .statusCode(500)
+                .statusCode(403)
                 .body("errors", hasSize(1))
                 .body("errors[0]", is("Downstream system error."));
 


### PR DESCRIPTION
Public API will respond with a 403 status code either if the gateway account does not have PSP credentials configured or if the gateway account has been disabled.

Pass this status code on in the response for the create payment API in products so that this status code can be used by products-ui to display a more specific error message.