### PR TITLE
PP-6213 Make reference_number in payments table to VARCHAR(255)

### DIFF
--- a/src/main/resources/migrations/00044_update_reference_number_in_payments_to_varchar255.sql
+++ b/src/main/resources/migrations/00044_update_reference_number_in_payments_to_varchar255.sql
@@ -1,0 +1,4 @@
+--liquibase formatted sql
+
+--changeset uk.gov.pay:00044_update_reference_number_in_payments_to_varchar255
+ALTER TABLE payments ALTER COLUMN reference_number TYPE VARCHAR(255);


### PR DESCRIPTION
Change the type of the `reference_number` column in the `payments` table from `VARCHAR(50`) to `VARCHAR(255)`, which matches what we allow for references for payments elsewhere.

Since PostgreSQL 9.2, increasing the limit for a `VARCHAR` no longer requires a table rewrite (see https://www.postgresql.org/docs/9.2/release-9-2.html#AEN114949) so this migration should be safe.