### PR TITLE
PP-10004 M1 support for integration tests

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run provider pact tests
         run: |
           export MAVEN_REPO="$HOME/.m2"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Pull docker image dependencies
         run: |
-          docker pull govukpay/postgres:11.1
+          docker pull postgres:11.16
       - name: Run unit and integration tests
         run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>
         <mockito.version>4.8.0</mockito.version>
         <wiremock.version>2.34.0</wiremock.version>
-        <pay-java-commons.version>1.0.20221010091710</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20221018103433</pay-java-commons.version>
         <jackson.version>2.13.4</jackson.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <swaggger-version>2.2.4</swaggger-version>

--- a/src/test/java/uk/gov/pay/products/persistence/dao/DaoTestBase.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/DaoTestBase.java
@@ -23,7 +23,7 @@ public class DaoTestBase {
     private static final Logger logger = LoggerFactory.getLogger(DaoTestBase.class);
 
     @ClassRule
-    public static final PostgresDockerRule postgres = new PostgresDockerRule();
+    public static final PostgresDockerRule postgres = new PostgresDockerRule("11.16");
 
     static DatabaseTestHelper databaseHelper;
     static GuicedTestEnvironment env;
@@ -42,7 +42,7 @@ public class DaoTestBase {
         databaseHelper = new DatabaseTestHelper(Jdbi.create(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword()));
 
         try (Connection connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword())) {
-            Liquibase migrator = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            Liquibase migrator = new Liquibase("it-migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
             migrator.update("");
         }
 
@@ -52,7 +52,7 @@ public class DaoTestBase {
     @AfterClass
     public static void tearDown() {
         try (Connection connection = DriverManager.getConnection(postgres.getConnectionUrl(), postgres.getUsername(), postgres.getPassword())) {
-            Liquibase migrator = new Liquibase("migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
+            Liquibase migrator = new Liquibase("it-migrations.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(connection));
             migrator.dropAll();
         } catch (Exception e) {
             logger.error("Error reverting migrations", e);

--- a/src/test/resources/it-migrations.xml
+++ b/src/test/resources/it-migrations.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="install necessary extensions for integration tests" author="">
+        <sql>
+            CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+            CREATE EXTENSION IF NOT EXISTS "pg_trgm" WITH SCHEMA "pg_catalog";
+        </sql>
+    </changeSet>
+
+    <include file="migrations.xml" relativeToChangelogFile="false"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID

- removed use of `govuk/postgres:11`, baselining on architecture agnostic `postgres:11.16`
- updated test bases and rules to enable cross architecture support
- added integration tests specific liquibase changelog (`it-migrations.xml`) to initialise the database before migrations can be run
- updated GHA to use new images