### PR TITLE
BAU Unhide pay_api_token field from OpenApi spec

### DIFF
--- a/openapi/products_spec.yaml
+++ b/openapi/products_spec.yaml
@@ -674,6 +674,8 @@ components:
         name:
           type: string
           example: A name for the product
+        pay_api_token:
+          type: string
         price:
           type: integer
           format: int64

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -55,7 +55,6 @@ public class Product {
     @JsonProperty(FIELD_DESCRIPTION)
     private final String description;
     @JsonProperty(FIELD_PAY_API_TOKEN)
-    @Schema(hidden = true)
     private final String payApiToken;
     @Schema(example = "1050")
     @JsonProperty(FIELD_PRICE)


### PR DESCRIPTION
This field should be included as it is returned in responses.