### PR TITLE
PP-11228: Remove graphite metrics sending and config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-graphite</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.6.0</version>

--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -1,8 +1,5 @@
 package uk.gov.pay.products;
 
-import com.codahale.metrics.graphite.GraphiteReporter;
-import com.codahale.metrics.graphite.GraphiteSender;
-import com.codahale.metrics.graphite.GraphiteUDP;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.dropwizard.Application;
@@ -55,7 +52,7 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
     
     private static final boolean NON_STRICT_VARIABLE_SUBSTITUTOR = false;
     private static final String SERVICE_METRICS_NODE = "pay-products";
-    private static final int GRAPHITE_SENDING_PERIOD_SECONDS = 10;
+    private static final int METRICS_COLLECTION_PERIOD_SECONDS = 30;
 
     @Override
     public String getName() {
@@ -109,9 +106,8 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
                 .scheduledExecutorService("metricscollector")
                 .threads(1)
                 .build()
-                .scheduleAtFixedRate(metricsService::updateMetricData, 0, GRAPHITE_SENDING_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
+                .scheduleAtFixedRate(metricsService::updateMetricData, 0, METRICS_COLLECTION_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
 
-        initialiseGraphiteMetrics(configuration, environment);
         configuration.getEcsContainerMetadataUriV4().ifPresent(uri -> initialisePrometheusMetrics(environment, uri));
     }
 
@@ -120,14 +116,6 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
         CollectorRegistry collectorRegistry = new CollectorRegistry();
         collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
         environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
-    }
-
-    private static void initialiseGraphiteMetrics(ProductsConfiguration configuration, Environment environment) {
-        GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), configuration.getGraphitePort());
-        GraphiteReporter.forRegistry(environment.metrics())
-                .prefixedWith(SERVICE_METRICS_NODE)
-                .build(graphiteUDP)
-                .start(GRAPHITE_SENDING_PERIOD_SECONDS, TimeUnit.SECONDS);
     }
 
     private void attachExceptionMappersTo(JerseyEnvironment jersey) {

--- a/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
+++ b/src/main/java/uk/gov/pay/products/config/ProductsConfiguration.java
@@ -11,11 +11,6 @@ import java.util.Optional;
 
 public class ProductsConfiguration extends Configuration {
 
-    @NotNull
-    private String graphiteHost;
-    @NotNull
-    private Integer graphitePort;
-
     @Valid
     @NotNull
     private DataSourceFactory dataSourceFactory;
@@ -59,14 +54,6 @@ public class ProductsConfiguration extends Configuration {
 
     @JsonProperty("ecsContainerMetadataUriV4")
     private URI ecsContainerMetadataUriV4;
-
-    public String getGraphiteHost() {
-        return graphiteHost;
-    }
-
-    public Integer getGraphitePort() {
-        return graphitePort;
-    }
 
     @JsonProperty("database")
     public DataSourceFactory getDataSourceFactory() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -28,9 +28,6 @@ logging:
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -18,9 +18,6 @@ logging:
     # Liquibase is very chatty and we only want to hear from it if things go wrong
     "liquibase": WARN
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}


### PR DESCRIPTION
## WHAT YOU DID
1. Remove graphite metrics configuration and sending
2. Rename GRAPHITE_SENDING_PERIOD_SECONDS to METRICS_COLLECTION_PERIOD_SECONDS, and set it to the appropriate value.

## How to test

Check build passes and explicitly wait for the e2e tests to pass

## Code review checklist

### Logging

- [X] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [X] Updated README.md for any of the following ?

* ~Introduced any new environment variables~ / removed existing environment variable
* ~Added new API / updated existing API definition~
