### PR TITLE
PP-11154: Update initialise prometheus metrics

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -5,4 +5,8 @@ set -e
 cd "$(dirname "$0")"
 
 mvn -DskipITs clean verify
-docker build -t govukpay/products:local .
+if [ "$(uname -m)" == "arm64" ]; then
+  docker build -t governmentdigitalservice/pay-products:local -f m1/arm64.Dockerfile .
+else
+  docker build -t governmentdigitalservice/pay-products:local .
+fi

--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -35,12 +35,10 @@ import uk.gov.pay.products.resources.PaymentResource;
 import uk.gov.pay.products.resources.ProductResource;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
-import uk.gov.service.payments.commons.utils.prometheus.PrometheusDefaultLabelSampleBuilder;
 import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
 import uk.gov.service.payments.logging.LoggingFilter;
 import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 
-import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -108,13 +106,8 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
                 .build()
                 .scheduleAtFixedRate(metricsService::updateMetricData, 0, METRICS_COLLECTION_PERIOD_SECONDS / 2, TimeUnit.SECONDS);
 
-        configuration.getEcsContainerMetadataUriV4().ifPresent(uri -> initialisePrometheusMetrics(environment, uri));
-    }
-
-    private void initialisePrometheusMetrics(Environment environment, URI ecsContainerMetadataUri) {
-        LOGGER.info("Initialising prometheus metrics.");
-        CollectorRegistry collectorRegistry = new CollectorRegistry();
-        collectorRegistry.register(new DropwizardExports(environment.metrics(), new PrometheusDefaultLabelSampleBuilder(ecsContainerMetadataUri)));
+        CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+        collectorRegistry.register(new DropwizardExports(environment.metrics()));
         environment.admin().addServlet("prometheusMetrics", new MetricsServlet(collectorRegistry)).addMapping("/metrics");
     }
 


### PR DESCRIPTION
## WHAT YOU DID
Now we don't need to build our default labels in the app (since they are now added by the sidecar) we should remove the default sample builder.

1. Remove default sample builder
2. Update local build script to account for m1 macs, and use the correct container tag

## How to test

This change has already been rolled out to connector and is working well.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [X] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
