### PR TITLE
PP-11652 Upgrade EclipseLink from 2.7.11 to 2.7.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>2.1.7</dropwizard.version>
-        <eclipselink.version>2.7.11</eclipselink.version>
+        <eclipselink.version>2.7.13</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>


### PR DESCRIPTION
Unlike version 2.7.11, 2.7.13 works with Java 21.

with @SandorArpa