### PR TITLE
PP-11288-Add-Error-Handling-For-Zero-Amount-Payment-Link

### DIFF
--- a/src/main/java/uk/gov/pay/products/validations/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/PaymentRequestValidator.java
@@ -32,6 +32,10 @@ public class PaymentRequestValidator {
         if (errors.isPresent()) {
             return Optional.of(Errors.from(errors.get()));
         }
+        errors = requestValidations.checkIsGreaterThanZero(payload, FIELD_PRICE);
+        if (errors.isPresent()) {
+            return Optional.of(Errors.from(errors.get()));
+        }
         errors = requestValidations.checkIsBelowMaxAmount(payload, FIELD_PRICE);
         return errors.map(Errors::from);
     }

--- a/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
@@ -17,9 +17,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.math.NumberUtils.isDigits;
 
 public class RequestValidations {
-
     static final Long MAX_PRICE = 10000000L;
-    static final Long ZERO_PRICE = 0L;
     
     Optional<List<String>> checkIsNumeric(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotNumeric(), fieldNames, "Field [%s] must be a number");
@@ -99,7 +97,7 @@ public class RequestValidations {
     }
 
     private static Function<JsonNode, Boolean> isNotGreaterThanZero() {
-        return jsonNode -> isDigits(jsonNode.asText()) && jsonNode.asLong() == ZERO_PRICE;
+        return jsonNode -> isDigits(jsonNode.asText()) && jsonNode.asLong() == 0L;
     }
 
     private static Function<JsonNode, Boolean> isNotString() {

--- a/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
+++ b/src/main/java/uk/gov/pay/products/validations/RequestValidations.java
@@ -19,9 +19,14 @@ import static org.apache.commons.lang3.math.NumberUtils.isDigits;
 public class RequestValidations {
 
     static final Long MAX_PRICE = 10000000L;
-
+    static final Long ZERO_PRICE = 0L;
+    
     Optional<List<String>> checkIsNumeric(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotNumeric(), fieldNames, "Field [%s] must be a number");
+    }
+
+    Optional<List<String>> checkIsGreaterThanZero(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotGreaterThanZero(), fieldNames, "Field [%s] must be £0.01 or more");
     }
     
     Optional<List<String>> checkIsString(JsonNode payload, String... fieldNames) {
@@ -91,6 +96,10 @@ public class RequestValidations {
 
     private static Function<JsonNode, Boolean> isNotNumeric() {
         return jsonNode -> !isDigits(jsonNode.asText());
+    }
+
+    private static Function<JsonNode, Boolean> isNotGreaterThanZero() {
+        return jsonNode -> isDigits(jsonNode.asText()) && jsonNode.asLong() == ZERO_PRICE;
     }
 
     private static Function<JsonNode, Boolean> isNotString() {

--- a/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.products.validations;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.products.util.Errors;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static junit.framework.TestCase.assertFalse;
@@ -38,13 +38,13 @@ public class PaymentRequestValidatorTest {
 
     @Test
     public void shouldSuccess_onCreatePayment_ifJsonPayloadHasValidPrice() {
-        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "1900")));
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(Map.of("price", "1900")));
         assertFalse(errors.isPresent());
     }
 
     @Test
     public void shouldError_onCreatePayment_ifJsonPayloadHasInvalidField() {
-        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("blah", "1900")));
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(Map.of("blah", "1900")));
         assertTrue(errors.isPresent());
 
         assertThat(errors.get().getErrors().size(), is(1));
@@ -53,7 +53,7 @@ public class PaymentRequestValidatorTest {
 
     @Test
     public void shouldError_onCreatePayment_ifJsonPayloadHasNonNumeric() {
-        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "blah")));
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(Map.of("price", "blah")));
         assertTrue(errors.isPresent());
 
         assertThat(errors.get().getErrors().size(), is(1));
@@ -62,7 +62,7 @@ public class PaymentRequestValidatorTest {
 
     @Test
     public void shouldError_onCreatePayment_ifJsonPayloadPriceIsZero() {
-        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "0")));
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(Map.of("price", "0")));
         assertTrue(errors.isPresent());
 
         assertThat(errors.get().getErrors().size(), is(1));
@@ -71,7 +71,7 @@ public class PaymentRequestValidatorTest {
 
     @Test
     public void shouldError_onCreatePayment_ifJsonPayloadBiggerThanMaxAmount() {
-        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "100000001")));
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(Map.of("price", "100000001")));
         assertTrue(errors.isPresent());
 
         assertThat(errors.get().getErrors().size(), is(1));

--- a/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/PaymentRequestValidatorTest.java
@@ -61,6 +61,15 @@ public class PaymentRequestValidatorTest {
     }
 
     @Test
+    public void shouldError_onCreatePayment_ifJsonPayloadPriceIsZero() {
+        Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "0")));
+        assertTrue(errors.isPresent());
+
+        assertThat(errors.get().getErrors().size(), is(1));
+        assertThat(errors.get().getErrors(), hasItem("Field [price] must be £0.01 or more"));
+    }
+
+    @Test
     public void shouldError_onCreatePayment_ifJsonPayloadBiggerThanMaxAmount() {
         Optional<Errors> errors = requestValidator.validatePriceOverrideRequest(objectMapper.valueToTree(ImmutableMap.of("price", "100000001")));
         assertTrue(errors.isPresent());


### PR DESCRIPTION
## WHAT YOU DID
- Updating the payment request validation logic in the PaymentResource.createPayment.
- The PaymentResource.createPayment endpoint  should respond with a meaningfully error message for a £0 prefilled payment link amount. At the moment, a NullPointerException is thrown.

## How to test

- How should it be reviewed? 
An engineer with experience of the E2E payment journey for prefilled payment link
- What feedback do you need? 
The error is triggered from the products-ui and a more user friendly message is displayed as propagated from the pay-products API's change
- If manual testing is needed, give suggested testing steps.
Though, some unit tests were created, manual testing will involve standing up the self service frontend, products-ui and the product api and then simulate the error as per `https://payments-platform.atlassian.net/browse/PP-11288` and check the pay-product logs and sentry e.g. similar to `https://govuk-pay.sentry.io/issues/4323719084/?project=5480169&query=&referrer=project-issue-stream`. @alexbishop1 has suggested code inspection should suffice instead of sentry check
