### PR TITLE
BAU add dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,26 @@ updates:
   - dependency-name: "eclipse-temurin"
     versions:
     - "> 11"
+  - dependency-name: "io.dropwizard:dropwizard-dependencies"
+    # Dropwizard 4.x only works with Jakarta EE and not Java EE
+    versions:
+      - ">= 4"
+  - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
+    # dropwizard-testing-junit4 only works with Dropwizard 4.x
+    versions:
+      - ">= 4"
+  - dependency-name: "org.dhatim:dropwizard-sentry"
+    # We essentially forked Dropwizard Sentry because it did not support
+    # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports
+    # Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work
+    # to go back to using an unmodified version
+    versions:
+      - ">= 4"
+  - dependency-name: "com.google.inject:guice-bom"
+    # Guice 6.x requires compatibility work on our side
+    # Guice 7.x only works with Jakarta EE and not Java EE
+    versions:
+      - ">= 6"
   open-pull-requests-limit: 10
   labels:
   - dependencies


### PR DESCRIPTION
## WHAT YOU DID

We need to ignore a few dependabot update that cannot be upgraded for different reasons.
