### PR TITLE
PP-12232 Use SecureRandom

### DIFF
--- a/src/main/java/uk/gov/pay/products/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/products/util/RandomIdGenerator.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.products.util;
 
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.UUID;
 
 import static java.util.stream.IntStream.range;
 
 public class RandomIdGenerator {
 
-    private static final Random RANDOM = new Random();
+    private static final SecureRandom RANDOM = new SecureRandom();
     /**
      * source
      */
@@ -32,7 +32,7 @@ public class RandomIdGenerator {
      * @return a user friendly reference of the format XXXXXXXXXX
      */
     public static String randomUserFriendlyReference() {
-        Random random = new Random();
+        SecureRandom random = new SecureRandom();
         StringBuilder sb = new StringBuilder();
         range(0, 10)
                 .forEach(i -> {


### PR DESCRIPTION
CodeQL flagged up use of insecure randomness. This shouldn't cause a vulnerability, as it was just used in test code and for generating user reference numbers. Use SecureRandom rather than Random so CodeQL won't raise this again in the future.