### PR TITLE
PP-12520 Move ignored Maven dependency updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,70 +1,72 @@
+---
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 10
-  labels:
-  - dependencies
-  - govuk-pay
-  - java
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
-  ignore:
-  - dependency-name: "eclipse-temurin"
-    versions:
-    - "> 11"
-  open-pull-requests-limit: 10
-  labels:
-  - dependencies
-  - govuk-pay
-  - docker
-- package-ecosystem: docker
-  directory: "/m1"
-  schedule:
-    interval: daily
-    time: "03:00"
-  ignore:
-  - dependency-name: "eclipse-temurin"
-    versions:
-    - "> 11"
-  - dependency-name: "io.dropwizard:dropwizard-dependencies"
-    # Dropwizard 4.x only works with Jakarta EE and not Java EE
-    versions:
-      - ">= 4"
-  - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
-    # dropwizard-testing-junit4 only works with Dropwizard 4.x
-    versions:
-      - ">= 4"
-  - dependency-name: "org.dhatim:dropwizard-sentry"
-    # We essentially forked Dropwizard Sentry because it did not support
-    # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports
-    # Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work
-    # to go back to using an unmodified version
-    versions:
-      - ">= 4"
-  - dependency-name: "com.google.inject:guice-bom"
-    # Guice 6.x requires compatibility work on our side
-    # Guice 7.x only works with Jakarta EE and not Java EE
-    versions:
-      - ">= 6"
-  open-pull-requests-limit: 10
-  labels:
-  - dependencies
-  - govuk-pay
-  - docker
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 0
-  labels:
-  - dependencies
-  - govuk-pay
-  - github_actions
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    ignore:
+      - dependency-name: "io.dropwizard:dropwizard-dependencies"
+        # Dropwizard 4.x only works with Jakarta EE and not Java EE
+        versions:
+          - ">= 4"
+      - dependency-name: "io.dropwizard.modules:dropwizard-testing-junit4"
+        # dropwizard-testing-junit4 4.x only works with Dropwizard 4.x
+        versions:
+          - ">= 4"
+      - dependency-name: "org.dhatim:dropwizard-sentry"
+        # We essentially forked Dropwizard Sentry because it did not support
+        # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports
+        # Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work
+        # to go back to using an unmodified version
+        versions:
+          - ">= 4"
+      - dependency-name: "com.google.inject:guice-bom"
+        # Guice 6.x requires compatibility work on our side
+        # Guice 7.x only works with Jakarta EE and not Java EE
+        versions:
+          - ">= 6"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - govuk-pay
+      - java
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        versions:
+          - "> 11"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - govuk-pay
+      - docker
+  - package-ecosystem: docker
+    directory: "/m1"
+    schedule:
+      interval: daily
+      time: "03:00"
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        versions:
+          - "> 11"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - govuk-pay
+      - docker
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - govuk-pay
+      - github_actions


### PR DESCRIPTION
Move ignored Maven dependency updates to the right place in the Dependabot configuration.

Also fix problems reported by `yamllint`.