### PR TITLE
PP-12767 Remove unnecessary logging

### DIFF
--- a/src/main/java/uk/gov/pay/products/resources/PaymentResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/PaymentResource.java
@@ -82,7 +82,6 @@ public class PaymentResource {
     )
     public Response findPaymentByExternalId(@Parameter(example = "h6347634cwb67wii7b6ciueroytw")
                                             @PathParam("paymentExternalId") String paymentExternalId) {
-        logger.info("Find a payment with externalId - [ {} ]", paymentExternalId);
         return paymentFactory.paymentFinder().findByExternalId(paymentExternalId)
                 .map(payment ->
                         Response.status(OK).entity(payment).build())
@@ -111,7 +110,6 @@ public class PaymentResource {
                                                                   description = "Price override for the payment amount. If not present this will defaults to price of product."))
                                           }))
                                           JsonNode payload) {
-        logger.info("Create a payment for product id - [ {} ]", productExternalId);
         return requestValidator.validatePriceOverrideRequest(payload)
                 .map(errors -> Response.status(Response.Status.BAD_REQUEST).entity(errors).build())
                 .orElseGet(() -> {
@@ -148,7 +146,6 @@ public class PaymentResource {
             }
     )
     public Response findPaymentsByProductExternalId(@Parameter(example = "uier837y735n837475y3847534") @PathParam("productExternalId") String productExternalId) {
-        logger.info("Find a list of payments for product id - [ {} ]", productExternalId);
         List<Payment> payments = paymentFactory.paymentFinder().findByProductExternalId(productExternalId);
         return payments.size() > 0 ? Response.status(OK).entity(payments).build() : Response.status(NOT_FOUND).build();
     }

--- a/src/main/java/uk/gov/pay/products/resources/ProductResource.java
+++ b/src/main/java/uk/gov/pay/products/resources/ProductResource.java
@@ -115,7 +115,6 @@ public class ProductResource {
             }
     )
     public Response findProductByExternalId(@PathParam("productExternalId") @Parameter(example = "874h5c87834659q345698495") String productExternalId) {
-        logger.info("Find a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().findByExternalId(productExternalId)
                 .map(product ->
                         Response.status(OK).entity(product).build())
@@ -139,7 +138,6 @@ public class ProductResource {
     )
     public Response findProductByGatewayAccountIdAndExternalId(@Parameter(example = "1") @PathParam("gatewayAccountId") Integer gatewayAccountId,
                                                                @Parameter(example = "874h5c87834659q345698495") @PathParam("productExternalId") String productExternalId) {
-        logger.info("Find a product with externalId - [ {} ]", productExternalId);
         return productFactory.productFinder().findByGatewayAccountIdAndExternalId(gatewayAccountId, productExternalId)
                 .map(product ->
                         Response.status(OK).entity(product).build())
@@ -328,7 +326,6 @@ public class ProductResource {
     public Response findProductByProductPath(
             @Parameter(example = "some-awesome-government-service") @QueryParam("serviceNamePath") String serviceNamePath,
             @Parameter(example = "name-for-product") @QueryParam("productNamePath") String productNamePath) {
-        logger.info(format("Searching for product with product path - [ serviceNamePath=%s productNamePath=%s ]", serviceNamePath, productNamePath));
         return productFactory.productFinder().findByProductPath(serviceNamePath, productNamePath)
                 .map(product -> Response.status(OK).entity(product).build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());


### PR DESCRIPTION
The latest IT Healthcheck identified a number of logging statements which could potentially result in unsanitised PII being logged. In several of these cases, these logging statements were found to be unnecessary as the relevant information is already logged in the API call, so they are being removed rather than spending time investigating the risk around logging PII.

- remove unnecessary logging statements