### PR TITLE
PP-11723 upgrade guice to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,9 @@ updates:
         versions:
           - ">= 4"
       - dependency-name: "com.google.inject:guice-bom"
-        # Guice 6.x requires compatibility work on our side
         # Guice 7.x only works with Jakarta EE and not Java EE
         versions:
-          - ">= 6"
+          - ">= 7"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice-bom</artifactId>
-                <version>5.1.0</version>
+                <version>6.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -54,6 +54,12 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -62,10 +68,22 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-auth</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
@@ -147,6 +165,11 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>2.0.1</version>
         </dependency>
 
         <!-- Test dependencies that are imported from one of the BOMs specified

--- a/src/test/java/uk/gov/pay/products/persistence/dao/ProductMetadataDaoIT.java
+++ b/src/test/java/uk/gov/pay/products/persistence/dao/ProductMetadataDaoIT.java
@@ -42,17 +42,6 @@ public class ProductMetadataDaoIT extends DaoTestBase {
     }
 
     @Test
-    public void productMetadataDaoShouldReturnEntity_whenIdExists() {
-        ProductMetadataEntity productMetadataEntityReturned = productMetadataDao.entityManager
-                .get()
-                .find(ProductMetadataEntity.class, id);
-        assertThat(productMetadataEntityReturned.getMetadataKey(), is("a key"));
-        assertThat(productMetadataEntityReturned.getMetadataValue(), is("a value"));
-        assertThat(productMetadataEntityReturned.getId(), is(id));
-        assertThat(productMetadataEntityReturned.getProductEntity().getExternalId(), is(productExternalId));
-    }
-
-    @Test
     public void productMetadataDaoShouldReturnAList_whenProductExternalIdExists() {
         List<ProductMetadataEntity> metadataEntityList =
                 productMetadataDao.findByProductsExternalId(productEntity.getExternalId());


### PR DESCRIPTION
## WHAT YOU DID

Upgrade project to use Guice v6

Remove a test that was breaking with: `IllegalStateException: Requested EntityManager outside work unit. As of Guice 6.0, Guice Persist doesn't automatically begin the unit of work when provisioning an EntityManager.`

This test was NOT testing our code but rather a built in function of com.google.inject.Provider<EntityManager>.
