### PR TITLE
PP-12712 Log misconfigured account error as WARN not ERROR

### DIFF
--- a/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
@@ -12,6 +12,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE;
 import static uk.gov.pay.products.util.PublicAPIErrorCodes.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
@@ -27,6 +28,8 @@ public class PaymentCreationExceptionMapper implements ExceptionMapper<PaymentCr
         if (CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE.equals(exception.getErrorCode())) {
             errorIdentifier = CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
             logger.info(PaymentCreationException.class.getName() + " thrown due to " + CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE);
+        } else if (ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE.equals(exception.getErrorCode())) {
+            logger.warn("PaymentCreationException thrown due to " + ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE + ". The account is not fully configured.");
         } else {
             logger.error("PaymentCreationException thrown.", exception);
         }

--- a/src/main/java/uk/gov/pay/products/util/PublicAPIErrorCodes.java
+++ b/src/main/java/uk/gov/pay/products/util/PublicAPIErrorCodes.java
@@ -3,4 +3,5 @@ package uk.gov.pay.products.util;
 public class PublicAPIErrorCodes {
 
      public static final String CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE = "P0105";
+     public static final String ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE = "P0940";
 }


### PR DESCRIPTION
Context: Payment links created from not-yet-configured accounts are causing multiple Sentry alerts. A Zendesk alert is considered preferable

- Handle a misconfigured exception by logging at WARN level rather than as an ERROR
- A splunk alert will be set up to look for these logs and alert Zendesk