### PR TITLE
PP-12712 Log payment creation errors at WARN level

### DIFF
--- a/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiRestClient.java
+++ b/src/main/java/uk/gov/pay/products/client/publicapi/PublicApiRestClient.java
@@ -52,7 +52,7 @@ public class PublicApiRestClient {
         }
 
         PublicApiResponseErrorException publicApiResponseErrorException = new PublicApiResponseErrorException(response);
-        logger.error("Public API client returned an error - [ {} ]", publicApiResponseErrorException.getMessage());
+        logger.warn("Public API client returned an error - [ {} ]", publicApiResponseErrorException.getMessage());
         throw publicApiResponseErrorException;
     }
 

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -151,7 +151,7 @@ public class PaymentCreator {
                         kv("product_external_id", paymentEntity.getProductEntity().getExternalId())
                 );
             } catch (PublicApiResponseErrorException e) {
-                logger.error("Payment creation for product external id {} failed {}", paymentEntity.getProductEntity().getExternalId(), e.getMessage());
+                logger.warn("Payment creation for product external id {} failed {}", paymentEntity.getProductEntity().getExternalId(), e.getMessage());
                 paymentEntity.setStatus(PaymentStatus.ERROR);
                 paymentEntity.setErrorStatusCode(e.getErrorStatus());
                 paymentEntity.setErrorCode(e.getCode());


### PR DESCRIPTION
- If a payment link fails due to a misconfigured account, we want a log at WARN level rather than ERROR, to avoid Sentry noise
- Amend logging statements to WARN if there is an error in the response from publicapi
- A previous PR ensured that the resulting PaymentCreationException will log at WARN level if the cause is a misconfigured account (but did not address the ERROR logs in the create payment process covered here)
- PaymentCreationException will continue to log at ERROR level for other causes of payment creation error