### PR TITLE
PP-13084: Fix number of metadata keys allowed

### DIFF
--- a/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
+++ b/src/main/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidator.java
@@ -31,7 +31,7 @@ public class ProductsMetadataRequestValidator {
             return Optional.of(Errors.from(EMPTY_METADATA_KEY_ERROR_MESSAGE, "EMPTY_METADATA_KEY"));
         }
 
-        if (metadataLoad.size() >= ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
+        if (metadataLoad.size() > ExternalMetadata.MAX_KEY_VALUE_PAIRS) {
             return Optional.of(Errors.from(MAX_NUMBER_OF_METADATA_ALLOWED_ERROR_MSG, "MAX_METADATA_LENGTH_EXCEEDED"));
         }
 

--- a/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/products/validations/ProductsMetadataRequestValidatorTest.java
@@ -42,9 +42,7 @@ public class ProductsMetadataRequestValidatorTest {
     @Test
     public void shouldErrorOnTooManyKeyValuePairsForProductCreate() {
         Map<String, String> mapToJson = new HashMap<>();
-        for (int count = 1; count < 17; count++) {
-            mapToJson.put("key" + count, "value" + count);
-        }
+        IntStream.rangeClosed(1, 16).forEach(i -> mapToJson.put("key" + i, "value" + i));
         JsonNode payload = new ObjectMapper().valueToTree(Map.of("metadata", mapToJson));
         Optional<Errors> errors = validator.validateMetadata(payload);
         assertThat(errors.isPresent(), is(true));


### PR DESCRIPTION
Should be able to have 15 metadata keys.