### PR TITLE
PP-13511: Deal with amount errors when creating a payment

### DIFF
--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -50,7 +50,6 @@ public class ProductsApplication extends Application<ProductsConfiguration> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProductsApplication.class);
     
     private static final boolean NON_STRICT_VARIABLE_SUBSTITUTOR = false;
-    private static final String SERVICE_METRICS_NODE = "pay-products";
     private static final int METRICS_COLLECTION_PERIOD_SECONDS = 30;
 
     @Override

--- a/src/main/java/uk/gov/pay/products/exception/PaymentCreationException.java
+++ b/src/main/java/uk/gov/pay/products/exception/PaymentCreationException.java
@@ -6,7 +6,8 @@ public class PaymentCreationException extends RuntimeException {
     private final int errorStatusCode;
     private final String errorCode;
 
-    public PaymentCreationException(String productExternalId, int errorStatusCode, String errorCode) {
+    public PaymentCreationException(String productExternalId, int errorStatusCode, String errorCode, String errorDescription) {
+        super(errorDescription);
         this.productExternalId = productExternalId;
         this.errorStatusCode = errorStatusCode;
         this.errorCode = errorCode;
@@ -22,5 +23,15 @@ public class PaymentCreationException extends RuntimeException {
 
     public String getErrorCode() {
         return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentCreationException{" +
+                "productExternalId='" + productExternalId + '\'' +
+                ", errorStatusCode=" + errorStatusCode +
+                ", errorCode='" + errorCode + '\'' +
+                ", message='" + getMessage() + '\'' +
+                '}';
     }
 }

--- a/src/main/java/uk/gov/pay/products/exception/PublicApiResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/products/exception/PublicApiResponseErrorException.java
@@ -20,11 +20,6 @@ public class PublicApiResponseErrorException extends RuntimeException {
         response.close();
     }
 
-
-    public PublicApiResponseErrorException(Throwable cause) {
-        super(cause);
-    }
-
     public int getErrorStatus() {
         return status;
     }

--- a/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.products.exception.mapper;
 
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.products.exception.PaymentCreationException;
@@ -10,7 +11,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import static java.lang.String.format;
-import static org.apache.http.HttpStatus.*;
 import static uk.gov.pay.products.util.PublicAPIErrorCodes.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR;
 import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_VALIDATION_ERROR;
@@ -60,9 +60,9 @@ public class PaymentCreationExceptionMapper implements ExceptionMapper<PaymentCr
 
     private int getStatus(PaymentCreationException exception) {
         return switch (exception.getErrorCode()) {
-            case CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR -> SC_BAD_REQUEST;
-            case CREATE_PAYMENT_VALIDATION_ERROR -> SC_UNPROCESSABLE_ENTITY;
-            default -> exception.getErrorStatusCode() == SC_FORBIDDEN ? SC_FORBIDDEN : SC_INTERNAL_SERVER_ERROR;
+            case CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR -> HttpStatus.SC_BAD_REQUEST;
+            case CREATE_PAYMENT_VALIDATION_ERROR -> HttpStatus.SC_UNPROCESSABLE_ENTITY;
+            default -> exception.getErrorStatusCode() == HttpStatus.SC_FORBIDDEN ? HttpStatus.SC_FORBIDDEN : HttpStatus.SC_INTERNAL_SERVER_ERROR;
         };
     }
 }

--- a/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/products/exception/mapper/PaymentCreationExceptionMapper.java
@@ -9,42 +9,60 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static uk.gov.pay.products.util.PublicAPIErrorCodes.ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE;
-import static uk.gov.pay.products.util.PublicAPIErrorCodes.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE;
+import static java.lang.String.format;
+import static org.apache.http.HttpStatus.*;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.ACCOUNT_NOT_LINKED_WITH_PSP;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_VALIDATION_ERROR;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AMOUNT_BELOW_MINIMUM;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED;
 
 public class PaymentCreationExceptionMapper implements ExceptionMapper<PaymentCreationException> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-
-
+    
     @Override
     public Response toResponse(PaymentCreationException exception) {
         ErrorIdentifier errorIdentifier = GENERIC;
-        if (CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE.equals(exception.getErrorCode())) {
-            errorIdentifier = CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
-            logger.info(PaymentCreationException.class.getName() + " thrown due to " + CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE);
-        } else if (ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE.equals(exception.getErrorCode())) {
-            logger.warn("PaymentCreationException thrown due to " + ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE + ". The account is not fully configured.");
-        } else {
-            logger.error("PaymentCreationException thrown.", exception);
+        
+        switch (exception.getErrorCode()) {
+            case ACCOUNT_NOT_LINKED_WITH_PSP -> 
+                logger.warn(format("PaymentCreationException thrown due to %s. The account is not fully configured.", 
+                        ACCOUNT_NOT_LINKED_WITH_PSP));
+            case CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR -> {
+                errorIdentifier = CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
+                logger.info(format("%s thrown due to %s. Reason: %s", PaymentCreationException.class.getName(), 
+                        CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR, exception.getMessage()));
+            }
+            case CREATE_PAYMENT_VALIDATION_ERROR -> {
+                /* 
+                The following is rather dirty, but differentiating between the two cases requires deeper thinking
+                about amending the response from publicapi 
+                */
+                if (exception.getMessage().contains("Must be greater than or equal to 30")) {
+                    errorIdentifier = AMOUNT_BELOW_MINIMUM;
+                } else {
+                    errorIdentifier = ZERO_AMOUNT_NOT_ALLOWED;    
+                }
+                logger.info(format("%s thrown due to %s. Reason: %s", PaymentCreationException.class.getName(), 
+                        CREATE_PAYMENT_VALIDATION_ERROR, exception.getMessage()));
+            }
+            default -> logger.error("PaymentCreationException thrown.", exception);
         }
 
         return Response
                 .status(getStatus(exception))
-                .entity(Errors.from("Downstream system error.", errorIdentifier.toString()))
+                .entity(Errors.from("Upstream system error.", errorIdentifier.toString()))
                 .build();
     }
 
-    private Response.Status getStatus(PaymentCreationException exception) {
-        if (CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE.equals(exception.getErrorCode())) {
-            return BAD_REQUEST;
-        }
-
-        return exception.getErrorStatusCode() == FORBIDDEN.getStatusCode() ? FORBIDDEN : INTERNAL_SERVER_ERROR;
+    private int getStatus(PaymentCreationException exception) {
+        return switch (exception.getErrorCode()) {
+            case CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR -> SC_BAD_REQUEST;
+            case CREATE_PAYMENT_VALIDATION_ERROR -> SC_UNPROCESSABLE_ENTITY;
+            default -> exception.getErrorStatusCode() == SC_FORBIDDEN ? SC_FORBIDDEN : SC_INTERNAL_SERVER_ERROR;
+        };
     }
 }

--- a/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/PaymentEntity.java
@@ -54,6 +54,8 @@ public class PaymentEntity extends AbstractEntity {
     private int errorStatusCode;
     @Transient
     private String errorCode;
+    @Transient
+    private String errorDescription;
 
     public PaymentEntity() {
     }
@@ -168,5 +170,13 @@ public class PaymentEntity extends AbstractEntity {
 
     public String getErrorCode() {
         return errorCode;
+    }
+
+    public void setErrorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+    }
+
+    public String getErrorDescription() {
+        return errorDescription;
     }
 }

--- a/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
+++ b/src/main/java/uk/gov/pay/products/service/PaymentCreator.java
@@ -29,7 +29,7 @@ import javax.inject.Inject;
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static uk.gov.pay.products.util.PublicAPIErrorCodes.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUserFriendlyReference;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
@@ -68,13 +68,14 @@ public class PaymentCreator {
                 .complete().get(PaymentEntity.class);
 
         if (paymentEntity.getStatus() == PaymentStatus.ERROR) {
-            if (CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE.equals(paymentEntity.getErrorCode())) {
+            if (CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR.equals(paymentEntity.getErrorCode())) {
                 paymentFactory.paymentUpdater().redactReferenceByExternalId(paymentEntity.getExternalId());
             }
 
             throw new PaymentCreationException(paymentEntity.getProductEntity().getExternalId(),
                     paymentEntity.getErrorStatusCode(),
-                    paymentEntity.getErrorCode());
+                    paymentEntity.getErrorCode(),
+                    paymentEntity.getErrorDescription());
         }
         return linksDecorator.decorate(paymentEntity.toPayment());
     }
@@ -155,6 +156,7 @@ public class PaymentCreator {
                 paymentEntity.setStatus(PaymentStatus.ERROR);
                 paymentEntity.setErrorStatusCode(e.getErrorStatus());
                 paymentEntity.setErrorCode(e.getCode());
+                paymentEntity.setErrorDescription(e.getDescription());
             }
 
             return paymentEntity;

--- a/src/main/java/uk/gov/pay/products/util/PublicAPIErrorCodes.java
+++ b/src/main/java/uk/gov/pay/products/util/PublicAPIErrorCodes.java
@@ -2,6 +2,7 @@ package uk.gov.pay.products.util;
 
 public class PublicAPIErrorCodes {
 
-     public static final String CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE = "P0105";
-     public static final String ACCOUNT_NOT_LINKED_WITH_PSP_ERROR_CODE = "P0940";
+     public static final String CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR = "P0105";
+     public static final String ACCOUNT_NOT_LINKED_WITH_PSP = "P0940";
+     public static final String CREATE_PAYMENT_VALIDATION_ERROR = "P0102";
 }

--- a/src/test/java/uk/gov/pay/products/extension/ProductsAppWithPostgresExtension.java
+++ b/src/test/java/uk/gov/pay/products/extension/ProductsAppWithPostgresExtension.java
@@ -1,0 +1,117 @@
+package uk.gov.pay.products.extension;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+import uk.gov.pay.products.ProductsApplication;
+import uk.gov.pay.products.config.PersistenceServiceInitialiser;
+import uk.gov.pay.products.config.ProductsConfiguration;
+import uk.gov.pay.products.config.ProductsModule;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.sql.DriverManager.getConnection;
+
+public class ProductsAppWithPostgresExtension implements BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProductsAppWithPostgresExtension.class);
+    private static final PostgreSQLContainer<?> postgresContainer;
+    private static final String DB_USERNAME = "test";
+    private static final String DB_PASSWORD = "test"; // pragma: allowlist secret
+    
+    private final DropwizardAppExtension<ProductsConfiguration> dropwizardAppExtension;
+    public final WireMockServer publicApi = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
+    public final WireMockServer publicAuth = new WireMockServer(wireMockConfig().dynamicPort().bindAddress("localhost"));
+    private Injector injector;
+
+    public ProductsAppWithPostgresExtension() {
+        publicApi.start();
+        publicAuth.start();
+        this.dropwizardAppExtension = new DropwizardAppExtension<>(
+                ProductsApplication.class,
+                resourceFilePath("config/test-it-config.yaml"),
+                config("database.url", postgresContainer.getJdbcUrl()),
+                config("database.user", DB_USERNAME),
+                config("database.password", DB_PASSWORD),
+                config("publicApiUrl", "http://localhost:" + publicApi.port()),
+                config("publicAuthUrl", "http://localhost:" + publicAuth.port()));
+
+        try {
+            // starts dropwizard application. This is required as we don't use DropwizardExtensionsSupport (which starts application)
+            // due to config overrides we need at runtime for database, sqs and any custom configuration needed for tests
+            dropwizardAppExtension.before();
+        } catch (Exception e) {
+            logger.error("Exception starting application - {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+        
+        injector = Guice.createInjector(new ProductsModule(dropwizardAppExtension.getConfiguration(), dropwizardAppExtension.getEnvironment()));
+        injector.getInstance(PersistenceServiceInitialiser.class);
+    }
+
+    public <T> T getInstanceFromGuiceContainer(Class<T> klazz) {
+        return injector.getInstance(klazz);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        if (context.getRequiredTestClass().getEnclosingClass() == null) {
+            publicApi.stop();
+            publicAuth.stop();
+            dropwizardAppExtension.after();
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        publicAuth.resetAll();
+        publicApi.resetAll();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        if (context.getRequiredTestClass().getEnclosingClass() == null) {
+            // Only runs if there is no enclosing class, i.e. not in a @Nested block
+            dropwizardAppExtension.getApplication().run("db", "migrate", resourceFilePath("config/test-it-config.yaml"));
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {}
+
+    public int getPort() {
+        return dropwizardAppExtension.getLocalPort();
+    }
+
+    static {
+        final String databaseName = "products";
+
+        postgresContainer = new PostgreSQLContainer<>("postgres:15.2")
+                .withUsername(DB_USERNAME)
+                .withPassword(DB_PASSWORD);
+
+        postgresContainer.start();
+
+        try (Connection connection = getConnection(postgresContainer.getJdbcUrl(), DB_USERNAME, DB_PASSWORD)) {
+            connection.createStatement().execute("CREATE DATABASE " + databaseName + " WITH owner=" + DB_USERNAME + " TEMPLATE postgres");
+            connection.createStatement().execute("GRANT ALL PRIVILEGES ON DATABASE " + databaseName + " TO " + DB_USERNAME);
+            connection.createStatement().execute("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+            connection.createStatement().execute("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/products/resources/CreatePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/CreatePaymentResourceIT.java
@@ -1,0 +1,102 @@
+package uk.gov.pay.products.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import uk.gov.pay.products.extension.ProductsAppWithPostgresExtension;
+import uk.gov.pay.products.persistence.dao.PaymentDao;
+import uk.gov.pay.products.persistence.dao.ProductDao;
+import uk.gov.pay.products.persistence.entity.PaymentEntity;
+import uk.gov.pay.products.persistence.entity.ProductEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.products.fixtures.ProductEntityFixture.aProductEntity;
+import static uk.gov.pay.products.util.PaymentStatus.ERROR;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_VALIDATION_ERROR;
+import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class CreatePaymentResourceIT {
+
+    @RegisterExtension
+    public static ProductsAppWithPostgresExtension app = new ProductsAppWithPostgresExtension();
+    
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    
+    private ProductDao productDao;
+    private PaymentDao paymentDao;
+    private ProductEntity productEntity;
+
+    @BeforeEach
+    void setUp() {
+        productDao = app.getInstanceFromGuiceContainer(ProductDao.class);
+        paymentDao = app.getInstanceFromGuiceContainer(PaymentDao.class);
+        productEntity = aProductEntity()
+                .withExternalId(randomUuid())
+                .withGatewayAccountId(0)
+                .withReferenceEnabled(true)
+                .build();
+        productDao.persist(productEntity);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "AMOUNT_BELOW_MINIMUM, \"Invalid attribute value: amount. Must be greater than or equal to 30. Refer to https://docs.payments.service.gov.uk/making_payments/#amount\"", 
+            "ZERO_AMOUNT_NOT_ALLOWED, \"Invalid attribute value: amount. Must be greater than or equal to 1. Refer to https://docs.payments.service.gov.uk/making_payments/#amount\""
+    })
+    void create_payment_should_fail_when_publicapi_returns_P0102_error_code(String expectedIdentifier, String publicApiErrorDescription) throws Exception {
+        stubPublicApiCreatePaymentResponse(publicApiErrorDescription);
+        
+        given().port(app.getPort())
+                .contentType(JSON)
+                .accept(APPLICATION_JSON)
+                .body(Map.of("reference_number", "a ref", "price", 29))
+                .post(format("/v1/api/products/%s/payments", productEntity.getExternalId()))
+                .then()
+                .statusCode(422)
+                .body("errors", hasSize(1))
+                .body("error_identifier", is(expectedIdentifier))
+                .body("errors[0]", is("Upstream system error."));
+
+        List<PaymentEntity> paymentEntities = paymentDao.findByProductExternalId(productEntity.getExternalId());
+        assertThat(paymentEntities, hasSize(1));
+        PaymentEntity paymentEntity = paymentEntities.getFirst();
+        assertThat(paymentEntity.getStatus(), is(ERROR));
+        assertThat(paymentEntity.getAmount(), nullValue());
+        assertThat(paymentEntity.getReferenceNumber(), is("a ref"));
+        assertThat(paymentEntity.getGovukPaymentId(), nullValue());
+    }
+    
+    private void stubPublicApiCreatePaymentResponse(String description) throws Exception {
+        Map<String, String> response = Map.of(
+                "field", "amount",
+                "code", CREATE_PAYMENT_VALIDATION_ERROR,
+                "description", description);
+        app.publicApi.stubFor(post(urlPathEqualTo("/v1/payments"))
+                .withHeader(AUTHORIZATION, matching("Bearer " + productEntity.getPayApiToken()))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_JSON))
+                .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withStatus(422)
+                        .withBody(objectMapper.writeValueAsString(response))));
+    }
+}

--- a/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
+++ b/src/test/java/uk/gov/pay/products/service/PaymentCreatorTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static uk.gov.pay.products.util.PaymentStatus.ERROR;
 import static uk.gov.pay.products.util.PaymentStatus.SUBMITTED;
-import static uk.gov.pay.products.util.PublicAPIErrorCodes.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE;
+import static uk.gov.pay.products.util.PublicAPIErrorCodes.CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
 import static uk.gov.service.payments.commons.model.Source.CARD_AGENT_INITIATED_MOTO;
 import static uk.gov.service.payments.commons.model.Source.CARD_PAYMENT_LINK;
@@ -553,7 +553,7 @@ public class PaymentCreatorTest {
 
         PublicApiResponseErrorException responseErrorException = mock(PublicApiResponseErrorException.class);
         when(responseErrorException.getErrorStatus()).thenReturn(BAD_REQUEST.getStatusCode());
-        when(responseErrorException.getCode()).thenReturn(CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR_CODE);
+        when(responseErrorException.getCode()).thenReturn(CREATE_PAYMENT_CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_ERROR);
         when(responseErrorException.getMessage()).thenReturn("Public API returned an error");
         when(publicApiRestClient.createPayment(argThat(is(productApiToken)), argThat(PaymentRequestMatcher.isSame(expectedPaymentRequest))))
                 .thenThrow(responseErrorException);

--- a/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
+++ b/src/test/java/uk/gov/pay/products/stubs/publicapi/PublicApiStub.java
@@ -19,6 +19,11 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+/**
+ * @deprecated See {@link uk.gov.pay.products.resources.CreatePaymentResourceIT}. That class's 
+ * stubPublicApiCreatePaymentResponse constructs a Map object and use an ObjectMapper to serialise it to a json string
+ * which is easier. It also uses junit5. 
+ */
 public class PublicApiStub {
     private static final String PAYMENTS_PATH = "/v1/payments";
     private static final String PAYMENT_PATH = PAYMENTS_PATH + "/%s";


### PR DESCRIPTION
When creating a payment against publicapi and there is an issue with the amount - i.e. cannot be zero or cannot be less than 30p where a service uses Stripe - publicapi responds with a 422 and an error body:
```
{
    "field": "amount",
    "code": "P0102",
    "description": "Invalid attribute value: amount. Must be greater than or equal to 1. Refer to https://docs.payments.service.gov.uk/making_payments/#amount" // or "Invalid attribute value: amount. Must be greater than or equal to 30. Refer to https://docs.payments.service.gov.uk/making_payments/#amount"
}
```

For these validation errors, in response to a `POST /v1/api/products/{productExternalId}/payments`, the products app should return a 422 status code with the body
```
{
    "errors": [
        "Upstream system error."
    ],
    "error_identifier": "AMOUNT_BELOW_MINIMUM" // or ZERO_AMOUNT_NOT_ALLOWED
}
```

This is covered by CreatePaymentResourceIT.

This commit also introduces some improvements:
* Updating PaymentCreationExceptionMapper to:
  * use new Java 21 switch features
  * amend "Downstream" to "Upstream". Upstream means APIs products is dependent on; Downstream means callers of the products API.
* Aligning PublicAPIErrorCodes field names to be the same as publicapi's [RequestError.Code enum names](https://github.com/alphagov/pay-publicapi/blob/master/src/main/java/uk/gov/pay/api/model/RequestError.java#L14). This is to make referencing error codes between projects easier.
* CreatePaymentResourceIT is a junit5 test. Being the first one the ProductsAppWithPostgresExtension class is introduced. This test gets the Dao's directly which avoids having to get a handle on a database test helper so one can write sql statements directly to the database; I feel this is easier and cleaner.