### PR TITLE
PP-14315 Order payment links by created date

### DIFF
--- a/openapi/products_spec.yaml
+++ b/openapi/products_spec.yaml
@@ -616,6 +616,9 @@ components:
         amount_hint:
           type: string
           example: Enter an amount in multiples of £2 for the number of permits required
+        date_created:
+          type: string
+          format: date-time
         description:
           type: string
           example: Description of the product

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -11,8 +11,11 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
+import uk.gov.service.payments.commons.api.json.IsoInstantMillisecondSerializer;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -99,6 +102,8 @@ public class Product {
     private final Boolean requireCaptcha;
     @JsonIgnore
     private List<ProductMetadata> metadata;
+    @JsonSerialize(using = IsoInstantMillisecondSerializer.class)
+    private Instant dateCreated;
 
     public Product(String externalId,
                    String name,
@@ -115,7 +120,7 @@ public class Product {
                    List<ProductMetadata> metadata) {
         this(externalId, name, description, payApiToken, price, status, gatewayAccountId, type, returnUrl,
                 serviceNamePath, productNamePath, false, null, null,
-                null, language, false, metadata);
+                null, language, false, metadata, null);
     }
 
     public Product(
@@ -136,7 +141,8 @@ public class Product {
             String amountHint,
             SupportedLanguage language,
             Boolean requireCaptcha,
-            List<ProductMetadata> metadata) {
+            List<ProductMetadata> metadata,
+            Instant dateCreated) {
         this.externalId = externalId;
         this.name = name;
         this.description = description;
@@ -155,6 +161,7 @@ public class Product {
         this.language = language;
         this.requireCaptcha = requireCaptcha;
         this.metadata = metadata;
+        this.dateCreated = dateCreated;
     }
 
     public static Product from(JsonNode jsonPayload) {
@@ -180,7 +187,7 @@ public class Product {
 
         return new Product(externalId, name, description, payApiToken, price, ProductStatus.ACTIVE, gatewayAccountId,
                 type, returnUrl, serviceNamePath, productNamePath, referenceEnabled, referenceLabel, referenceHint,
-                amountHint, language, false, metadataList);
+                amountHint, language, false, metadataList, null);
     }
 
     public String getName() {

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -11,10 +11,10 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.products.util.ProductStatus;
 import uk.gov.pay.products.util.ProductType;
-import uk.gov.service.payments.commons.api.json.IsoInstantMillisecondSerializer;
+import uk.gov.service.payments.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -101,8 +101,8 @@ public class Product {
     private final Boolean requireCaptcha;
     @JsonIgnore
     private List<ProductMetadata> metadata;
-    @JsonSerialize(using = IsoInstantMillisecondSerializer.class)
-    private final Instant dateCreated;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private final ZonedDateTime dateCreated;
 
     public Product(String externalId,
                    String name,
@@ -141,7 +141,7 @@ public class Product {
             SupportedLanguage language,
             Boolean requireCaptcha,
             List<ProductMetadata> metadata,
-            Instant dateCreated) {
+            ZonedDateTime dateCreated) {
         this.externalId = externalId;
         this.name = name;
         this.description = description;

--- a/src/main/java/uk/gov/pay/products/model/Product.java
+++ b/src/main/java/uk/gov/pay/products/model/Product.java
@@ -15,7 +15,6 @@ import uk.gov.service.payments.commons.api.json.IsoInstantMillisecondSerializer;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -103,7 +102,7 @@ public class Product {
     @JsonIgnore
     private List<ProductMetadata> metadata;
     @JsonSerialize(using = IsoInstantMillisecondSerializer.class)
-    private Instant dateCreated;
+    private final Instant dateCreated;
 
     public Product(String externalId,
                    String name,

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
@@ -271,7 +271,7 @@ public class ProductEntity extends AbstractEntity {
                         .stream()
                         .map(ProductMetadata::from)
                         .collect(Collectors.toList()),
-                this.dateCreated.toInstant());
+                this.dateCreated);
     }
 
     public Map<String, String> toProductMetadataMap() {

--- a/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
+++ b/src/main/java/uk/gov/pay/products/persistence/entity/ProductEntity.java
@@ -270,7 +270,8 @@ public class ProductEntity extends AbstractEntity {
                 this.metadataEntityList == null ? null : this.metadataEntityList
                         .stream()
                         .map(ProductMetadata::from)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()),
+                this.dateCreated.toInstant());
     }
 
     public Map<String, String> toProductMetadataMap() {

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
@@ -27,12 +27,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.products.fixtures.PaymentEntityFixture.aPaymentEntity;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomInt;
 import static uk.gov.pay.products.util.RandomIdGenerator.randomUuid;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class ProductResourceIT {
 
@@ -516,7 +516,7 @@ public class ProductResourceIT {
                     .body(DESCRIPTION, is(product.getDescription()))
                     .body(RETURN_URL, is(product.getReturnUrl()))
                     .body(LANGUAGE, is("en"))
-                    .body(DATE_CREATED, is(notNullValue()));
+                    .body(DATE_CREATED, is(app.getDatabaseTestHelper().getFixedDateTime().format(ISO_INSTANT_MILLISECOND_PRECISION)));
 
             String productsUrl = "https://products.url/v1/api/products/";
             String productsUIPayUrl = "https://products-ui.url/pay/";

--- a/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
+++ b/src/test/java/uk/gov/pay/products/resources/ProductResourceIT.java
@@ -2,8 +2,6 @@ package uk.gov.pay.products.resources;
 
 import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.hamcrest.Matcher;
-import org.hamcrest.core.CombinableMatcher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -18,9 +16,6 @@ import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import jakarta.ws.rs.HttpMethod;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.chrono.ChronoZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -29,12 +24,9 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
@@ -1392,9 +1384,5 @@ public class ProductResourceIT {
                     .body("size()", is(1))
                     .body("[0].product.external_id", is(product.getExternalId()));
         }
-    }
-
-    private CombinableMatcher<ChronoZonedDateTime<?>> isCloseTo(ZonedDateTime now) {
-        return both(greaterThan(now.minusSeconds(30))).and(lessThan(now.plusSeconds(30)));
     }
 }

--- a/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/products/utils/DatabaseTestHelper.java
@@ -4,9 +4,14 @@ import org.jdbi.v3.core.Jdbi;
 import uk.gov.pay.products.model.Payment;
 import uk.gov.pay.products.model.Product;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static java.time.ZoneOffset.UTC;
 
 public class DatabaseTestHelper {
 
@@ -21,12 +26,12 @@ public class DatabaseTestHelper {
                 "(external_id, name, description, pay_api_token, price, " +
                 "status, return_url, type, gateway_account_id, " +
                 "service_name_path, product_name_path, reference_enabled, " +
-                "reference_label, reference_hint, language, require_captcha) " +
+                "reference_label, reference_hint, language, require_captcha, date_created) " +
                 "VALUES " +
                 "(:external_id, :name, :description, :pay_api_token, :price, " +
                 ":status, :return_url, :type, :gateway_account_id, " +
                 ":service_name_path, :product_name_path, :reference_enabled, " +
-                ":reference_label, :reference_hint, :language, :require_captcha" +
+                ":reference_label, :reference_hint, :language, :require_captcha, :date_created" +
                 ")")
                 .bind("external_id", product.getExternalId())
                 .bind("name", product.getName())
@@ -44,8 +49,14 @@ public class DatabaseTestHelper {
                 .bind("reference_hint", product.getReferenceHint())
                 .bind("language", product.getLanguage().toString())
                 .bind("require_captcha", product.isRequireCaptcha())
+                .bind("date_created", getFixedDateTime())
                 .execute());
 
+    }
+
+    public ZonedDateTime getFixedDateTime() {
+        Clock clock = Clock.fixed(Instant.parse("2025-01-01T10:00:00.00Z"), UTC);
+        return ZonedDateTime.ofInstant(clock.instant(), UTC);
     }
 
     public void addPayment(Payment payment, Integer gatewayAccountId) {


### PR DESCRIPTION
## WHAT YOU DID

- add created date (timestamp) to product response 

## How to test

- create at least two payment links locally 
- view the links in self-service using https://github.com/alphagov/pay-selfservice/pull/4684 
- the most recent payment link you created should be displayed at the top of the list 

