### PR TITLE
PP-13991 refactor to use vanilla SentryAppenderFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <hamcrest.version>3.0</hamcrest.version>
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>
         <pact.version>3.6.15</pact.version>
-        <pay-java-commons.version>1.0.20250818082133</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20250819140056</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <surefire.version>3.5.3</surefire.version>
         <swagger-version>2.2.36</swagger-version>
@@ -137,11 +137,6 @@
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging-dropwizard-4</artifactId>
             <version>${pay-java-commons.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dhatim</groupId>
-            <artifactId>dropwizard-sentry</artifactId>
-            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/src/main/java/uk/gov/pay/products/ProductsApplication.java
+++ b/src/main/java/uk/gov/pay/products/ProductsApplication.java
@@ -13,6 +13,7 @@ import io.dropwizard.migrations.MigrationsBundle;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.servlet.jakarta.exporter.MetricsServlet;
+import org.dhatim.dropwizard.sentry.logging.SentryAppenderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.products.config.PersistenceServiceInitialiser;
@@ -36,7 +37,6 @@ import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
 import uk.gov.service.payments.logging.LoggingFilter;
 import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
-import uk.gov.service.payments.logging.SentryAppenderFactory;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -25,7 +25,7 @@ logging:
       customFields:
         container: "products"
         environment: ${ENVIRONMENT}
-    - type: pay-dropwizard-4-sentry
+    - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}


### PR DESCRIPTION
## WHAT YOU DID

- We can migrate to 4.x now we use Dropwizard 4, which would allow us to remove some custom code.
- import `SentryAppenderFactory` from dropwizard-sentry.

