### PR TITLE
PP-15379 update github actions

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master
 


### PR DESCRIPTION
## WHAT YOU DID

Github retiring node20. Update actions to a node24 compatible version.
