### PR TITLE
PP-15698: bump pay java commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
+
     <groupId>uk.gov.pay</groupId>
     <artifactId>pay-products</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <prerequisites>
+        <maven>3.0.0</maven>
+    </prerequisites>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -47,7 +47,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <!-- Main dependencies that are imported from one of the BOMs specified
              in <dependencyManagement> so no explicit versions needed -->
@@ -391,6 +390,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>default</id>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,6 @@
     <artifactId>pay-products</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <hamcrest.version>3.0</hamcrest.version>
         <mainClass>uk.gov.pay.products.ProductsApplication</mainClass>
         <pact.version>3.6.15</pact.version>
-        <pay-java-commons.version>1.0.20260727084644</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260812081959</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <surefire.version>3.5.6</surefire.version>
         <swagger-version>2.2.52</swagger-version>


### PR DESCRIPTION
Bumps pay-java-commons to the latest version. This version removes the transitive io.dropwizard.metrics:metrics-graphite dependency. That dependency is not used here.

Additionally:
* Runs `mvn tidy:pom`
* Removes deprecated use of the `prerequisites` element that causes Maven to emit a warning. We do not enforce the minimum Maven version in other projects but in any case we ought to use the Maven Enforcer Plugin for this purpose. Reference: https://maven.apache.org/pom.html#Prerequisites)
